### PR TITLE
Enhance DefaultCacheManager with customizable cache directory and improved initialization

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.1.1] - 2026-02-20
+
+* **Fix:** Removed global `Hive.init()` usage from `DefaultCacheManager` to avoid conflicts with host app Hive initialization
+* **Fix:** Added initialization synchronization in `DefaultCacheManager` to prevent parallel cold-start race conditions
+* **Fix:** Switched cache metadata box opening to explicit `openBox(path: ...)` on a private Hive instance for reliable isolation
+* **Feature:** Added optional `cacheDirectoryProvider` parameter to `DefaultCacheManager` so apps can control cache storage location
+* **Tests:** Added regression tests for Hive init conflicts, concurrent initialization races, and cache directory resilience scenarios
+
 ## [4.1.0] - 2026-02-19
 
 * **Feature:** Added `httpClientFactory` parameter to `DefaultCacheManager` for HTTP client dependency injection, enabling easy mocking in tests

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -8,6 +8,8 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hive_ce/hive.dart';
+// ignore: implementation_imports
+import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
@@ -67,6 +69,11 @@ class CacheEntryMetadata {
   }
 }
 
+/// Signature for a function that returns the cache base directory.
+///
+/// Defaults to [getTemporaryDirectory] when not specified.
+typedef CacheDirectoryProvider = Future<io.Directory> Function();
+
 /// Default cache manager implementation using Hive CE for metadata storage,
 /// the http package for downloads, and path_provider for file system access.
 class DefaultCacheManager extends CacheManager with ImageCacheManager {
@@ -75,11 +82,18 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// [stalePeriod] is how long a file remains valid in the cache.
   /// [maxNrOfCacheObjects] is the maximum before cleanup triggers.
   /// [httpClientFactory] allows injecting a custom HTTP client (useful for testing).
+  /// [cacheDirectoryProvider] allows overriding where cache files are stored.
+  ///   Defaults to [getTemporaryDirectory]. Pass [getApplicationSupportDirectory]
+  ///   if you need a more persistent location (but note that files may be
+  ///   backed up on iOS/Android).
   DefaultCacheManager({
     this.stalePeriod = _kDefaultStalePeriod,
     this.maxNrOfCacheObjects = _kDefaultMaxCacheObjects,
     http.Client Function()? httpClientFactory,
-  }) : _httpClientFactory = httpClientFactory ?? http.Client.new;
+    CacheDirectoryProvider? cacheDirectoryProvider,
+  })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
+        _cacheDirectoryProvider =
+            cacheDirectoryProvider ?? getTemporaryDirectory;
 
   /// Duration before cached files are considered stale.
   final Duration stalePeriod;
@@ -90,24 +104,51 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// Factory for creating HTTP clients (injectable for testing).
   final http.Client Function() _httpClientFactory;
 
+  /// Provider for the base cache directory.
+  final CacheDirectoryProvider _cacheDirectoryProvider;
+
+  /// Private Hive instance to avoid conflicts with the host app's global
+  /// [Hive] singleton. Each [DefaultCacheManager] gets its own isolated
+  /// Hive registry.
+  final HiveInterface _hive = HiveImpl();
+
   Box<Map>? _cacheBox;
   String? _cacheDir;
-  bool _initialized = false;
+
+  /// Guards [_doInit] so that concurrent callers (e.g. multiple images
+  /// loading at the same time on cold start) share the same init future.
+  Completer<void>? _initCompleter;
 
   /// Initialize Hive and open the cache metadata box.
-  Future<void> _ensureInitialized() async {
-    if (_initialized) return;
+  ///
+  /// Uses a [Completer] to ensure that only one initialization runs at a
+  /// time, even when multiple callers invoke this concurrently.
+  Future<void> _ensureInitialized() {
+    if (_initCompleter != null) return _initCompleter!.future;
+    _initCompleter = Completer<void>();
+    _doInit().then((_) {
+      _initCompleter!.complete();
+    }).catchError((Object e, StackTrace s) {
+      // Allow retry on next call by clearing the completer.
+      final completer = _initCompleter!;
+      _initCompleter = null;
+      completer.completeError(e, s);
+    });
+    return _initCompleter!.future;
+  }
 
-    final dir = await getTemporaryDirectory();
+  Future<void> _doInit() async {
+    final dir = await _cacheDirectoryProvider();
     _cacheDir = path.join(dir.path, 'cached_network_image_ce');
     await io.Directory(_cacheDir!).create(recursive: true);
 
-    if (!Hive.isBoxOpen(_kBoxName)) {
-      Hive.init(path.join(_cacheDir!, 'hive'));
-    }
+    final hivePath = path.join(_cacheDir!, 'hive');
+    await io.Directory(hivePath).create(recursive: true);
 
-    _cacheBox = await Hive.openBox<Map>(_kBoxName);
-    _initialized = true;
+    // Open the box with an explicit path on the private Hive instance.
+    // This avoids calling Hive.init() which would conflict with the
+    // host application's own Hive initialization.
+    _cacheBox = await _hive.openBox<Map>(_kBoxName, path: hivePath);
 
     // Run cleanup in background
     unawaited(_cleanupOldFiles());
@@ -374,7 +415,8 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     if (_cacheBox != null && _cacheBox!.isOpen) {
       await _cacheBox!.close();
     }
-    _initialized = false;
+    await _hive.close();
+    _initCompleter = null;
   }
 
   /// Clean up files that haven't been used in a while.

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -124,17 +124,28 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// Uses a [Completer] to ensure that only one initialization runs at a
   /// time, even when multiple callers invoke this concurrently.
   Future<void> _ensureInitialized() {
-    if (_initCompleter != null) return _initCompleter!.future;
-    _initCompleter = Completer<void>();
+    final currentCompleter = _initCompleter;
+    if (currentCompleter != null) return currentCompleter.future;
+
+    final completer = Completer<void>();
+    _initCompleter = completer;
+
     _doInit().then((_) {
-      _initCompleter!.complete();
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
     }).catchError((Object e, StackTrace s) {
-      // Allow retry on next call by clearing the completer.
-      final completer = _initCompleter!;
-      _initCompleter = null;
-      completer.completeError(e, s);
+      // Allow retry on next call by clearing the completer that initiated
+      // this initialization sequence.
+      if (identical(_initCompleter, completer)) {
+        _initCompleter = null;
+      }
+      if (!completer.isCompleted) {
+        completer.completeError(e, s);
+      }
     });
-    return _initCompleter!.future;
+
+    return completer.future;
   }
 
   Future<void> _doInit() async {
@@ -412,10 +423,22 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
   @override
   Future<void> dispose() async {
+    final inFlightInit = _initCompleter;
+    if (inFlightInit != null) {
+      try {
+        await inFlightInit.future;
+      } on Object catch (_) {
+        // Ignore init errors during dispose.
+      }
+    }
+
     if (_cacheBox != null && _cacheBox!.isOpen) {
       await _cacheBox!.close();
     }
     await _hive.close();
+
+    _cacheBox = null;
+    _cacheDir = null;
     _initCompleter = null;
   }
 

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.1.0
+version: 4.1.1
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -5,6 +5,7 @@ import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 
@@ -66,6 +67,666 @@ void main() {
         ),
       );
       expect(manager, isA<DefaultCacheManager>());
+    });
+
+    test('accepts custom cacheDirectoryProvider', () async {
+      final customDir =
+          io.Directory.systemTemp.createTempSync('custom_cache_dir_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+
+      await manager.putFile(
+        'https://example.com/custom-dir.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+
+      final cached =
+          await manager.getFileFromCache('https://example.com/custom-dir.bin');
+      expect(cached, isNotNull);
+
+      // Verify files are in the custom directory
+      final cacheSubDir = io.Directory('${customDir.path}/cached_network_image_ce');
+      expect(cacheSubDir.existsSync(), isTrue);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // ---- Concurrent initialization (race condition regression) ----
+
+  group('DefaultCacheManager concurrent initialization', () {
+    test('parallel operations on cold manager do not throw', () async {
+      final manager = DefaultCacheManager();
+
+      // Fire multiple cache operations in parallel before init completes.
+      // Before the fix this would trigger multiple Hive.init / openBox calls.
+      final futures = <Future>[];
+      for (var i = 0; i < 10; i++) {
+        futures.add(
+          manager.putFile(
+            'https://example.com/concurrent-$i.bin',
+            [i],
+            fileExtension: 'bin',
+          ),
+        );
+      }
+
+      // All should complete without error
+      await Future.wait(futures);
+
+      // Verify data integrity
+      for (var i = 0; i < 10; i++) {
+        final cached = await manager.getFileFromCache(
+          'https://example.com/concurrent-$i.bin',
+        );
+        expect(cached, isNotNull, reason: 'Entry $i should be cached');
+      }
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('parallel getFileFromCache on cold manager do not throw', () async {
+      final manager = DefaultCacheManager();
+
+      // Pre-populate via a single call, then dispose to reset state
+      await manager.putFile(
+        'https://example.com/parallel-get.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+      await manager.dispose();
+
+      // Now create a fresh manager and fire parallel reads
+      final manager2 = DefaultCacheManager();
+      final futures = List.generate(
+        10,
+        (_) => manager2.getFileFromCache(
+          'https://example.com/parallel-get.bin',
+        ),
+      );
+
+      final results = await Future.wait(futures);
+      // All should return the same cached entry
+      for (final result in results) {
+        expect(result, isNotNull);
+      }
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+  });
+
+  // ---- Hive isolation from host app ----
+
+  group('DefaultCacheManager Hive isolation', () {
+    test('does not conflict with global Hive singleton', () async {
+      // Simulate host app calling Hive.init with a different path
+      // (this would previously cause problems)
+      final hostDir =
+          io.Directory.systemTemp.createTempSync('host_hive_dir_');
+      addTearDown(() {
+        try {
+          hostDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      // The library's DefaultCacheManager should work independently
+      final manager = DefaultCacheManager();
+      await manager.putFile(
+        'https://example.com/isolated.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+
+      final cached = await manager.getFileFromCache(
+        'https://example.com/isolated.bin',
+      );
+      expect(cached, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('two DefaultCacheManager instances with separate dirs work independently',
+        () async {
+      final dir1 =
+          io.Directory.systemTemp.createTempSync('manager1_');
+      final dir2 =
+          io.Directory.systemTemp.createTempSync('manager2_');
+      addTearDown(() {
+        try {
+          dir1.deleteSync(recursive: true);
+        } on Object catch (_) {}
+        try {
+          dir2.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager1 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir1,
+      );
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir2,
+      );
+
+      await manager1.putFile(
+        'https://example.com/m1.bin',
+        [1],
+        fileExtension: 'bin',
+      );
+      await manager2.putFile(
+        'https://example.com/m2.bin',
+        [2],
+        fileExtension: 'bin',
+      );
+
+      // Both should find their own entries
+      expect(
+        await manager1.getFileFromCache('https://example.com/m1.bin'),
+        isNotNull,
+      );
+      expect(
+        await manager2.getFileFromCache('https://example.com/m2.bin'),
+        isNotNull,
+      );
+
+      await manager1.emptyCache();
+      await manager1.dispose();
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+  });
+
+  // ===========================================================================
+  // Regression tests for Hive init issues:
+  //   1. Global Hive.init() conflict with host app
+  //   2. Race condition in _ensureInitialized (concurrent callers)
+  //   3. Cache directory cleanup resilience
+  // ===========================================================================
+
+  // ---- Issue 1: Global Hive.init conflict ----
+
+  group('Regression: no global Hive.init conflict', () {
+    test('library works after host app calls Hive.init with a different path',
+        () async {
+      final hostDir =
+          io.Directory.systemTemp.createTempSync('host_hive_init_');
+      addTearDown(() {
+        try {
+          Hive.close();
+          hostDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      // Simulate what a host app does: call the global Hive.init
+      Hive.init(hostDir.path);
+
+      // The library should still function correctly using its own private
+      // Hive instance, not the global one.
+      final manager = DefaultCacheManager();
+      await manager.putFile(
+        'https://example.com/after-host-init.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+
+      final cached = await manager.getFileFromCache(
+        'https://example.com/after-host-init.bin',
+      );
+      expect(cached, isNotNull);
+      expect(cached!.originalUrl, 'https://example.com/after-host-init.bin');
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('host app Hive boxes remain unaffected by library usage', () async {
+      final hostDir =
+          io.Directory.systemTemp.createTempSync('host_hive_boxes_');
+      addTearDown(() {
+        try {
+          Hive.close();
+          hostDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      // Host app creates and uses its own box via the global Hive
+      Hive.init(hostDir.path);
+      final hostBox = await Hive.openBox<String>('host_app_box');
+      await hostBox.put('greeting', 'hello');
+
+      // Use the library's cache manager
+      final manager = DefaultCacheManager();
+      await manager.putFile(
+        'https://example.com/no-interference.bin',
+        [10, 20, 30],
+        fileExtension: 'bin',
+      );
+      await manager.emptyCache();
+      await manager.dispose();
+
+      // Host box data should be completely untouched
+      expect(hostBox.get('greeting'), 'hello');
+      await hostBox.close();
+    });
+
+    test('library does not register boxes on the global Hive singleton',
+        () async {
+      // Ensure the global Hive does not know about our box
+      final manager = DefaultCacheManager();
+      await manager.putFile(
+        'https://example.com/global-check.bin',
+        [1],
+        fileExtension: 'bin',
+      );
+
+      // The library's box should NOT be visible on the global Hive
+      expect(Hive.isBoxOpen('cached_network_image_cache'), isFalse);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // ---- Issue 2: Race condition in _ensureInitialized ----
+
+  group('Regression: _ensureInitialized race condition', () {
+    test('concurrent putFile calls on a cold manager all succeed', () async {
+      final manager = DefaultCacheManager();
+
+      // Launch 20 putFile calls simultaneously on a never-initialized manager.
+      // Before the Completer fix, this would trigger parallel Hive.init and
+      // openBox calls causing exceptions or data corruption.
+      final futures = List.generate(
+        20,
+        (i) => manager.putFile(
+          'https://example.com/race-put-$i.bin',
+          List.filled(i + 1, i),
+          fileExtension: 'bin',
+        ),
+      );
+
+      await Future.wait(futures);
+
+      // All 20 entries should be present and correct
+      for (var i = 0; i < 20; i++) {
+        final cached = await manager.getFileFromCache(
+          'https://example.com/race-put-$i.bin',
+        );
+        expect(cached, isNotNull, reason: 'Entry $i missing');
+        final bytes = await (cached!.file as io.File).readAsBytes();
+        expect(bytes.length, i + 1, reason: 'Entry $i has wrong length');
+      }
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('concurrent getFileStream calls on a cold manager all succeed',
+        () async {
+      var downloadCount = 0;
+      final manager = DefaultCacheManager(
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async {
+            downloadCount++;
+            return http.Response('data-${request.url}', 200);
+          },
+        ),
+      );
+
+      // Fire 10 getFileStream calls at the same instant
+      final streams = List.generate(
+        10,
+        (i) => manager
+            .getFileStream('https://example.com/race-stream-$i.png')
+            .toList(),
+      );
+
+      final results = await Future.wait(streams);
+
+      // Every stream should have completed with at least one FileInfo
+      for (var i = 0; i < 10; i++) {
+        final fileInfos = results[i].whereType<FileInfo>().toList();
+        expect(
+          fileInfos,
+          isNotEmpty,
+          reason: 'Stream $i should have a FileInfo',
+        );
+      }
+
+      // All 10 URLs should have been downloaded
+      expect(downloadCount, 10);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('mixed concurrent operations on a cold manager', () async {
+      final manager = DefaultCacheManager(
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('img', 200),
+        ),
+      );
+
+      // Mix of putFile, getFileFromCache, getFileStream, removeFile
+      final futures = <Future>[
+        manager.putFile('https://example.com/mix-put.bin', [1],
+            fileExtension: 'bin'),
+        manager.getFileFromCache('https://example.com/non-existent'),
+        manager.getFileStream('https://example.com/mix-stream.png').toList(),
+        manager.removeFile('https://example.com/also-non-existent'),
+        manager.putFile('https://example.com/mix-put2.bin', [2],
+            fileExtension: 'bin'),
+      ];
+
+      // All should complete without throwing
+      await Future.wait(futures);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('init failure allows retry on next call', () async {
+      var callCount = 0;
+
+      // First call will fail, second will succeed
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async {
+          callCount++;
+          if (callCount == 1) {
+            throw const io.FileSystemException('Simulated permission error');
+          }
+          return testTempDir;
+        },
+      );
+
+      // First call should fail
+      Object? error;
+      try {
+        await manager.putFile(
+          'https://example.com/retry-test.bin',
+          [1],
+          fileExtension: 'bin',
+        );
+      } on Object catch (e) {
+        error = e;
+      }
+      expect(error, isA<io.FileSystemException>());
+
+      // Second call should succeed (completer was cleared on error)
+      await manager.putFile(
+        'https://example.com/retry-test.bin',
+        [1],
+        fileExtension: 'bin',
+      );
+      final cached = await manager.getFileFromCache(
+        'https://example.com/retry-test.bin',
+      );
+      expect(cached, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('concurrent calls during init failure all receive the same error',
+        () async {
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async {
+          throw const io.FileSystemException('Simulated init failure');
+        },
+      );
+
+      // Launch 5 calls simultaneously, all should get the same error
+      final futures = List.generate(
+        5,
+        (i) => manager
+            .putFile(
+              'https://example.com/fail-$i.bin',
+              [i],
+              fileExtension: 'bin',
+            )
+            .then((_) => null as Object?)
+            .catchError((Object e) => e),
+      );
+
+      final results = await Future.wait(futures);
+      for (var i = 0; i < 5; i++) {
+        expect(
+          results[i],
+          isA<io.FileSystemException>(),
+          reason: 'Call $i should have received the init error',
+        );
+      }
+    });
+
+    test('rapid dispose-and-reuse cycle does not corrupt state', () async {
+      final manager = DefaultCacheManager();
+
+      for (var cycle = 0; cycle < 5; cycle++) {
+        await manager.putFile(
+          'https://example.com/cycle-$cycle.bin',
+          [cycle],
+          fileExtension: 'bin',
+        );
+        await manager.dispose();
+      }
+
+      // After the last dispose, re-initialize and check the last entry
+      final cached = await manager.getFileFromCache(
+        'https://example.com/cycle-4.bin',
+      );
+      expect(cached, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // ---- Issue 3: Cache directory / Hive metadata resilience ----
+
+  group('Regression: cache directory resilience', () {
+    test('recovers when Hive metadata dir is deleted but cache files remain',
+        () async {
+      final customDir =
+          io.Directory.systemTemp.createTempSync('resilience_hive_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+      await manager.putFile(
+        'https://example.com/resilience.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+
+      // Verify the file exists on disk
+      final cached = await manager.getFileFromCache(
+        'https://example.com/resilience.bin',
+      );
+      expect(cached, isNotNull);
+      expect(await (cached!.file as io.File).exists(), isTrue);
+      final filePath = cached.file.path;
+
+      await manager.dispose();
+
+      // Simulate OS purging the Hive directory (but not the cache files)
+      final hiveDir =
+          io.Directory('${customDir.path}/cached_network_image_ce/hive');
+      if (hiveDir.existsSync()) {
+        hiveDir.deleteSync(recursive: true);
+      }
+
+      // Verify the image file still exists
+      expect(io.File(filePath).existsSync(), isTrue);
+
+      // Re-create the manager — it should re-initialize cleanly
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+
+      // The metadata is gone so the old entry won't be found
+      final cached2 = await manager2.getFileFromCache(
+        'https://example.com/resilience.bin',
+      );
+      expect(cached2, isNull);
+
+      // But new entries should work fine
+      await manager2.putFile(
+        'https://example.com/resilience-new.bin',
+        [4, 5, 6],
+        fileExtension: 'bin',
+      );
+      final newCached = await manager2.getFileFromCache(
+        'https://example.com/resilience-new.bin',
+      );
+      expect(newCached, isNotNull);
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+
+    test('recovers when cache files are deleted but Hive metadata remains',
+        () async {
+      final customDir =
+          io.Directory.systemTemp.createTempSync('resilience_files_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+      await manager.putFile(
+        'https://example.com/file-gone.bin',
+        [7, 8, 9],
+        fileExtension: 'bin',
+      );
+
+      final cached =
+          await manager.getFileFromCache('https://example.com/file-gone.bin');
+      expect(cached, isNotNull);
+
+      // Simulate OS purging just the cached image file (not Hive data)
+      final imageFile = cached!.file as io.File;
+      await imageFile.delete();
+
+      // getFileFromCache should detect the missing file and return null
+      final cached2 =
+          await manager.getFileFromCache('https://example.com/file-gone.bin');
+      expect(cached2, isNull);
+
+      // New files should still work
+      await manager.putFile(
+        'https://example.com/file-gone.bin',
+        [10, 11, 12],
+        fileExtension: 'bin',
+      );
+      final cached3 =
+          await manager.getFileFromCache('https://example.com/file-gone.bin');
+      expect(cached3, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('recovers when entire cache directory is deleted', () async {
+      final customDir =
+          io.Directory.systemTemp.createTempSync('resilience_all_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+      await manager.putFile(
+        'https://example.com/all-gone.bin',
+        [1],
+        fileExtension: 'bin',
+      );
+      await manager.dispose();
+
+      // Nuke the entire cache directory tree
+      final cacheSubDir =
+          io.Directory('${customDir.path}/cached_network_image_ce');
+      if (cacheSubDir.existsSync()) {
+        cacheSubDir.deleteSync(recursive: true);
+      }
+
+      // Re-create and verify it rebuilds from scratch
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+
+      final cached =
+          await manager2.getFileFromCache('https://example.com/all-gone.bin');
+      expect(cached, isNull);
+
+      // Should be able to store new data
+      await manager2.putFile(
+        'https://example.com/rebuilt.bin',
+        [2],
+        fileExtension: 'bin',
+      );
+      final newCached =
+          await manager2.getFileFromCache('https://example.com/rebuilt.bin');
+      expect(newCached, isNotNull);
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+
+    test('cacheDirectoryProvider can specify application support directory',
+        () async {
+      // Verifies the constructor parameter works for non-temp directories
+      final supportDir =
+          io.Directory.systemTemp.createTempSync('app_support_sim_');
+      addTearDown(() {
+        try {
+          supportDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => supportDir,
+      );
+
+      await manager.putFile(
+        'https://example.com/support-dir.bin',
+        [1, 2, 3, 4, 5],
+        fileExtension: 'bin',
+      );
+
+      final cached = await manager.getFileFromCache(
+        'https://example.com/support-dir.bin',
+      );
+      expect(cached, isNotNull);
+
+      // Check that files live inside the custom directory, not temp dir
+      expect(cached!.file.path, contains(supportDir.path));
+      expect(cached.file.path, isNot(contains(testTempDir.path)));
+
+      await manager.emptyCache();
+      await manager.dispose();
     });
   });
 

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -93,7 +93,8 @@ void main() {
       expect(cached, isNotNull);
 
       // Verify files are in the custom directory
-      final cacheSubDir = io.Directory('${customDir.path}/cached_network_image_ce');
+      final cacheSubDir =
+          io.Directory('${customDir.path}/cached_network_image_ce');
       expect(cacheSubDir.existsSync(), isTrue);
 
       await manager.emptyCache();
@@ -172,8 +173,7 @@ void main() {
     test('does not conflict with global Hive singleton', () async {
       // Simulate host app calling Hive.init with a different path
       // (this would previously cause problems)
-      final hostDir =
-          io.Directory.systemTemp.createTempSync('host_hive_dir_');
+      final hostDir = io.Directory.systemTemp.createTempSync('host_hive_dir_');
       addTearDown(() {
         try {
           hostDir.deleteSync(recursive: true);
@@ -197,12 +197,11 @@ void main() {
       await manager.dispose();
     });
 
-    test('two DefaultCacheManager instances with separate dirs work independently',
+    test(
+        'two DefaultCacheManager instances with separate dirs work independently',
         () async {
-      final dir1 =
-          io.Directory.systemTemp.createTempSync('manager1_');
-      final dir2 =
-          io.Directory.systemTemp.createTempSync('manager2_');
+      final dir1 = io.Directory.systemTemp.createTempSync('manager1_');
+      final dir2 = io.Directory.systemTemp.createTempSync('manager2_');
       addTearDown(() {
         try {
           dir1.deleteSync(recursive: true);
@@ -259,8 +258,7 @@ void main() {
   group('Regression: no global Hive.init conflict', () {
     test('library works after host app calls Hive.init with a different path',
         () async {
-      final hostDir =
-          io.Directory.systemTemp.createTempSync('host_hive_init_');
+      final hostDir = io.Directory.systemTemp.createTempSync('host_hive_init_');
       addTearDown(() {
         try {
           Hive.close();


### PR DESCRIPTION
## Description

Enhance the DefaultCacheManager by introducing a customizable cache directory provider and improving initialization handling to prevent race conditions during concurrent access. Add regression tests to ensure reliability of these features.

## Related Issues

Fixes #2

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v4.1.1

* **New Features**
  * Added optional `cacheDirectoryProvider` parameter to DefaultCacheManager for custom cache directory control

* **Bug Fixes**
  * Fixed conflicts with host app Hive initialization through improved isolation
  * Improved thread-safe concurrent initialization handling
  * Enhanced cache resilience and prevented interference between manager instances

* **Tests**
  * Added regression tests for initialization conflicts, concurrent operations, and cache directory edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->