### PR TITLE
Add SVG support and image format detection

### DIFF
--- a/.github/scripts/setup_overrides.sh
+++ b/.github/scripts/setup_overrides.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Generate pubspec_overrides.yaml files so cross-package dependencies resolve
+# locally instead of requiring published versions on pub.dev.
+# This is essential for monorepo CI where sibling package versions may not yet
+# be published.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# cached_network_image (main package) depends on platform_interface + web
+cat > "$REPO_ROOT/cached_network_image/pubspec_overrides.yaml" << 'EOF'
+dependency_overrides:
+  cached_network_image_platform_interface_ce:
+    path: ../cached_network_image_platform_interface
+  cached_network_image_web_ce:
+    path: ../cached_network_image_web
+EOF
+
+# cached_network_image/example depends on platform_interface + web (transitively)
+cat > "$REPO_ROOT/cached_network_image/example/pubspec_overrides.yaml" << 'EOF'
+dependency_overrides:
+  cached_network_image_platform_interface_ce:
+    path: ../../cached_network_image_platform_interface
+  cached_network_image_web_ce:
+    path: ../../cached_network_image_web
+EOF
+
+# cached_network_image_web depends on platform_interface
+cat > "$REPO_ROOT/cached_network_image_web/pubspec_overrides.yaml" << 'EOF'
+dependency_overrides:
+  cached_network_image_platform_interface_ce:
+    path: ../cached_network_image_platform_interface
+EOF
+
+echo "Dependency overrides created successfully."

--- a/.github/workflows/app_facing_package.yaml
+++ b/.github/workflows/app_facing_package.yaml
@@ -42,6 +42,10 @@ jobs:
           architecture: x64
           cache: true
 
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
+
       # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
@@ -73,6 +77,10 @@ jobs:
           channel: "stable"
           architecture: x64
           cache: true
+
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
 
       # Download all Flutter packages
       - name: Download dependencies
@@ -113,6 +121,10 @@ jobs:
           architecture: x64
           cache: true
 
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
+
       # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
@@ -145,6 +157,10 @@ jobs:
           channel: "stable"
           architecture: x64
           cache: true
+
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
 
       # Download all Flutter packages
       - name: Download dependencies
@@ -184,6 +200,10 @@ jobs:
         run: flutter config --enable-macos-desktop
         working-directory: ${{env.source-directory}}
 
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
+
       # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
@@ -221,6 +241,11 @@ jobs:
       - name: Enable Windows
         run: flutter config --enable-windows-desktop
         working-directory: ${{env.source-directory}}
+
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        shell: bash
+        run: bash .github/scripts/setup_overrides.sh
 
       # Download all Flutter packages
       - name: Download dependencies
@@ -269,6 +294,10 @@ jobs:
         run: flutter doctor
         working-directory: ${{env.source-directory}}
 
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
+
       # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
@@ -302,6 +331,10 @@ jobs:
           architecture: x64
           cache: true
 
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
+
       # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
@@ -332,6 +365,10 @@ jobs:
           channel: "stable"
           architecture: x64
           cache: true
+
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
 
       # Download all Flutter packages
       - name: Download dependencies
@@ -390,6 +427,10 @@ jobs:
           channel: "stable"
           architecture: x64
           cache: true
+
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
 
       # Download all Flutter packages
       - name: Download dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,8 @@ jobs:
         with:
           channel: "stable"
           cache: true
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
       - name: Install dependencies
         run: flutter pub get
         working-directory: ./${{ matrix.package }}
@@ -47,6 +49,8 @@ jobs:
         with:
           channel: "stable"
           cache: true
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
       - name: Install dependencies
         run: flutter pub get
         working-directory: ./${{ matrix.package }}

--- a/.github/workflows/platform_web.yaml
+++ b/.github/workflows/platform_web.yaml
@@ -42,6 +42,10 @@ jobs:
           architecture: x64
           cache: true
 
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
+
       # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
@@ -74,6 +78,10 @@ jobs:
           architecture: x64
           cache: true
 
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
+
       # Download all Flutter packages
       - name: Download dependencies
         run: flutter pub get
@@ -100,6 +108,9 @@ jobs:
           channel: "stable"
           architecture: x64
           cache: true
+
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
 
       - name: Download dependencies
         run: flutter pub get
@@ -136,6 +147,10 @@ jobs:
           channel: "stable"
           architecture: x64
           cache: true
+
+      # Create dependency overrides for cross-package resolution
+      - name: Create dependency overrides
+        run: bash .github/scripts/setup_overrides.sh
 
       # Download all Flutter packages
       - name: Download dependencies

--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.2.0] - 2026-02-23
+
+* **Feature:** Added SVG support via new `unsupportedImageBuilder` callback
+  * New `UnsupportedImageFormatException` thrown when image format is not supported by Flutter's standard codec
+  * New `ImageFormatDetector` utility with content sniffing for SVG detection
+  * Images are still cached normally; only rendering path differs
+  * Example app updated with SVG demo using `flutter_svg`
+  * 24 new tests added (18 format detection + 6 widget integration)
+  * See README for usage example
+
 ## [4.1.1] - 2026-02-20
 
 * **Fix:** Removed global `Hive.init()` usage from `DefaultCacheManager` to avoid conflicts with host app Hive initialization

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -114,6 +114,29 @@ CachedNetworkImage(
 Image(image: CachedNetworkImageProvider(url))
 ```
 
+### SVG Support
+
+Flutter's built-in image codec doesn't support SVG. When `CachedNetworkImage`
+detects SVG bytes it throws an `UnsupportedImageFormatException`. Use the
+`unsupportedImageBuilder` callback to render them with any SVG package you
+prefer (e.g. [`flutter_svg`](https://pub.dev/packages/flutter_svg)):
+
+```dart
+CachedNetworkImage(
+  imageUrl: 'https://example.com/image.svg',
+  unsupportedImageBuilder: (context, url, bytes) {
+    // `bytes` are the already-cached file bytes.
+    return SvgPicture.memory(bytes); // from flutter_svg
+  },
+  placeholder: (context, url) => CircularProgressIndicator(),
+  errorWidget: (context, url, error) => Icon(Icons.error),
+),
+```
+
+The image is still downloaded and cached normally — only the **rendering**
+path is different. If `unsupportedImageBuilder` is not set, the error falls
+through to `errorWidget` with an `UnsupportedImageFormatException`.
+
 ## ❓ FAQ
 
 **Q: Will I lose my users' existing cache if I migrate?**

--- a/cached_network_image/devtools_options.yaml
+++ b/cached_network_image/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/cached_network_image/example/.metadata
+++ b/cached_network_image/example/.metadata
@@ -15,7 +15,7 @@ migration:
     - platform: root
       create_revision: 44a626f4f0027bc38a46dc68aed5964b05a83c18
       base_revision: 44a626f4f0027bc38a46dc68aed5964b05a83c18
-    - platform: android
+    - platform: ios
       create_revision: 44a626f4f0027bc38a46dc68aed5964b05a83c18
       base_revision: 44a626f4f0027bc38a46dc68aed5964b05a83c18
 

--- a/cached_network_image/example/devtools_options.yaml
+++ b/cached_network_image/example/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/cached_network_image/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/cached_network_image/example/ios/Runner.xcodeproj/project.pbxproj
@@ -11,12 +11,11 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
-		845491A81CC6DADD49884E95 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BAF365A656E88F5D376982DA /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		9AC918DDA6BDEC46AFF6EE16 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C8D8BE14711610888464056 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,15 +47,11 @@
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		57516DB51A8FCB6FAE9D408D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		58388594A59100AF53164C4F /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		6C6B7CDD3E05AE901508D551 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		767B119F414E402A5A6E8F2A /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		7C8D8BE14711610888464056 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -64,26 +59,14 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BAF365A656E88F5D376982DA /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CF2CEFE285100B95CB547542 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		DEF2E3CA84C51AA421363F9F /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		6736B5E9D32FD4D1707D88BF /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				845491A81CC6DADD49884E95 /* Pods_RunnerTests.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
-				9AC918DDA6BDEC46AFF6EE16 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,20 +79,6 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
-			sourceTree = "<group>";
-		};
-		46420A50F57F003A5CE9AD2C /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				CF2CEFE285100B95CB547542 /* Pods-Runner.debug.xcconfig */,
-				57516DB51A8FCB6FAE9D408D /* Pods-Runner.release.xcconfig */,
-				DEF2E3CA84C51AA421363F9F /* Pods-Runner.profile.xcconfig */,
-				58388594A59100AF53164C4F /* Pods-RunnerTests.debug.xcconfig */,
-				6C6B7CDD3E05AE901508D551 /* Pods-RunnerTests.release.xcconfig */,
-				767B119F414E402A5A6E8F2A /* Pods-RunnerTests.profile.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -131,8 +100,6 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
-				46420A50F57F003A5CE9AD2C /* Pods */,
-				A144FDF2554885F16467CF8D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -155,18 +122,10 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
-			sourceTree = "<group>";
-		};
-		A144FDF2554885F16467CF8D /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				7C8D8BE14711610888464056 /* Pods_Runner.framework */,
-				BAF365A656E88F5D376982DA /* Pods_RunnerTests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -176,10 +135,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				70894171D4953DC2A47EACD6 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
-				6736B5E9D32FD4D1707D88BF /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -195,7 +152,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				5C9F7B084F93C5B1F142360B /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -245,7 +201,7 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -295,50 +251,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		5C9F7B084F93C5B1F142360B /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		70894171D4953DC2A47EACD6 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -371,6 +283,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
+				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -463,7 +376,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 6UEL98K25V;
+				DEVELOPMENT_TEAM = M3A3B5P5JV;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -480,7 +393,6 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 58388594A59100AF53164C4F /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -498,7 +410,6 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6C6B7CDD3E05AE901508D551 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -514,7 +425,6 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 767B119F414E402A5A6E8F2A /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -646,7 +556,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 6UEL98K25V;
+				DEVELOPMENT_TEAM = M3A3B5P5JV;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -669,7 +579,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 6UEL98K25V;
+				DEVELOPMENT_TEAM = M3A3B5P5JV;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -720,7 +630,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};

--- a/cached_network_image/example/ios/Runner/Info.plist
+++ b/cached_network_image/example/ios/Runner/Info.plist
@@ -40,7 +40,7 @@
 					<key>UISceneConfigurationName</key>
 					<string>flutter</string>
 					<key>UISceneDelegateClassName</key>
-					<string>FlutterSceneDelegate</string>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
 					<string>Main</string>
 				</dict>

--- a/cached_network_image/example/ios/Runner/SceneDelegate.swift
+++ b/cached_network_image/example/ios/Runner/SceneDelegate.swift
@@ -1,0 +1,6 @@
+import Flutter
+import UIKit
+
+class SceneDelegate: FlutterSceneDelegate {
+
+}

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 import 'benchmark_page.dart';
 
@@ -71,12 +72,30 @@ class BasicContent extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             _blurHashImage(),
+             _sizedContainer(
+              CachedNetworkImage(
+                imageUrl:
+                    'https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg',
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
+                unsupportedImageBuilder: (context, url, bytes) =>
+                    SvgPicture.memory(
+                  bytes,
+                  fit: BoxFit.contain,
+                ),
+                errorWidget: (context, url, error) => const Icon(Icons.error),
+              ),
+            ),
             _sizedContainer(
               const Image(
+                width: double.infinity,
+                fit: BoxFit.fitWidth,
                 image: CachedNetworkImageProvider(
-                  'https://via.placeholder.com/350x150',
+                  'https://images.unsplash.com/photo-1614517453351-6c1522fc7a56',
                 ),
               ),
+              width: double.infinity,
+              height: 200,
             ),
             _sizedContainer(
               CachedNetworkImage(
@@ -93,15 +112,16 @@ class BasicContent extends StatelessWidget {
               CachedNetworkImage(
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                imageUrl: 'https://via.placeholder.com/200x150',
+                imageUrl: 'https://plus.unsplash.com/premium_photo-1695566086196-1cdadbaa1988?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
               ),
             ),
             _sizedContainer(
               CachedNetworkImage(
-                imageUrl: 'https://via.placeholder.com/300x150',
+                imageUrl: 'https://images.unsplash.com/photo-1644588815329-4705c4418d38?q=80&w=1473&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
                 imageBuilder: (context, imageProvider) => Container(
                   decoration: BoxDecoration(
                     image: DecorationImage(
+           
                       image: imageProvider,
                       fit: BoxFit.cover,
                       colorFilter: const ColorFilter.mode(
@@ -117,7 +137,7 @@ class BasicContent extends StatelessWidget {
               ),
             ),
             CachedNetworkImage(
-              imageUrl: 'https://via.placeholder.com/300x300',
+              imageUrl: 'https://images.unsplash.com/photo-1565343486673-fbd3a3ce9331?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
               placeholder: (context, url) => const CircleAvatar(
                 backgroundColor: Colors.amber,
                 radius: 150,
@@ -154,7 +174,7 @@ class BasicContent extends StatelessWidget {
             _sizedContainer(
               CachedNetworkImage(
                 maxHeightDiskCache: 10,
-                imageUrl: 'https://via.placeholder.com/350x200',
+                imageUrl: 'https://images.unsplash.com/photo-1706212074955-6045fce2521d?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
@@ -181,10 +201,10 @@ class BasicContent extends StatelessWidget {
     );
   }
 
-  Widget _sizedContainer(Widget child) {
+  Widget _sizedContainer(Widget child, {double width = double.infinity, double height = 250}) {
     return SizedBox(
-      width: 300,
-      height: 150,
+      width: width,
+      height: height,
       child: Center(child: child),
     );
   }

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -72,7 +72,7 @@ class BasicContent extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             _blurHashImage(),
-             _sizedContainer(
+            _sizedContainer(
               CachedNetworkImage(
                 imageUrl:
                     'https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg',
@@ -112,16 +112,17 @@ class BasicContent extends StatelessWidget {
               CachedNetworkImage(
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                imageUrl: 'https://plus.unsplash.com/premium_photo-1695566086196-1cdadbaa1988?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+                imageUrl:
+                    'https://plus.unsplash.com/premium_photo-1695566086196-1cdadbaa1988?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
               ),
             ),
             _sizedContainer(
               CachedNetworkImage(
-                imageUrl: 'https://images.unsplash.com/photo-1644588815329-4705c4418d38?q=80&w=1473&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+                imageUrl:
+                    'https://images.unsplash.com/photo-1644588815329-4705c4418d38?q=80&w=1473&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
                 imageBuilder: (context, imageProvider) => Container(
                   decoration: BoxDecoration(
                     image: DecorationImage(
-           
                       image: imageProvider,
                       fit: BoxFit.cover,
                       colorFilter: const ColorFilter.mode(
@@ -137,7 +138,8 @@ class BasicContent extends StatelessWidget {
               ),
             ),
             CachedNetworkImage(
-              imageUrl: 'https://images.unsplash.com/photo-1565343486673-fbd3a3ce9331?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+              imageUrl:
+                  'https://images.unsplash.com/photo-1565343486673-fbd3a3ce9331?q=80&w=1471&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
               placeholder: (context, url) => const CircleAvatar(
                 backgroundColor: Colors.amber,
                 radius: 150,
@@ -174,7 +176,8 @@ class BasicContent extends StatelessWidget {
             _sizedContainer(
               CachedNetworkImage(
                 maxHeightDiskCache: 10,
-                imageUrl: 'https://images.unsplash.com/photo-1706212074955-6045fce2521d?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+                imageUrl:
+                    'https://images.unsplash.com/photo-1706212074955-6045fce2521d?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
                 errorWidget: (context, url, error) => const Icon(Icons.error),
@@ -201,7 +204,8 @@ class BasicContent extends StatelessWidget {
     );
   }
 
-  Widget _sizedContainer(Widget child, {double width = double.infinity, double height = 250}) {
+  Widget _sizedContainer(Widget child,
+      {double width = double.infinity, double height = 250}) {
     return SizedBox(
       width: width,
       height: height,

--- a/cached_network_image/example/pubspec.yaml
+++ b/cached_network_image/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   flutter_blurhash: ^0.8.2
   flutter_cache_manager: ^3.4.1
+  flutter_svg: ^2.2.1
 
 dev_dependencies:
   flutter_test:

--- a/cached_network_image/example/pubspec_overrides.yaml
+++ b/cached_network_image/example/pubspec_overrides.yaml
@@ -1,7 +1,5 @@
 dependency_overrides:
   cached_network_image_platform_interface_ce:
-    path:
-      ../../cached_network_image_platform_interface
+    path: ../../cached_network_image_platform_interface
   cached_network_image_web_ce:
-    path:
-      ../../cached_network_image_web
+    path: ../../cached_network_image_web

--- a/cached_network_image/lib/cached_network_image.dart
+++ b/cached_network_image/lib/cached_network_image.dart
@@ -12,7 +12,9 @@ export 'package:cached_network_image_platform_interface_ce/cached_network_image_
         FileResponse,
         FileSource,
         HttpExceptionWithStatus,
-        ImageCacheManager;
+        ImageCacheManager,
+        ImageFormatDetector,
+        UnsupportedImageFormatException;
 
 export 'src/cache/default_cache_manager.dart';
 export 'src/cached_image_widget.dart';

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
 import 'package:flutter/material.dart';
@@ -33,6 +35,26 @@ typedef LoadingErrorWidgetBuilder = Widget Function(
   BuildContext context,
   String url,
   Object error,
+);
+
+/// Builder function to create a widget for images whose format is not
+/// supported by Flutter's standard image codec (e.g. SVG).
+///
+/// The [bytes] parameter contains the raw cached file bytes. Use a package
+/// like `flutter_svg` to render them:
+///
+/// ```dart
+/// CachedNetworkImage(
+///   imageUrl: 'https://example.com/image.svg',
+///   unsupportedImageBuilder: (context, url, bytes) {
+///     return SvgPicture.memory(bytes);
+///   },
+/// )
+/// ```
+typedef UnsupportedImageWidgetBuilder = Widget Function(
+  BuildContext context,
+  String url,
+  Uint8List bytes,
 );
 
 /// Image widget to show NetworkImage with caching functionality.
@@ -82,6 +104,19 @@ class CachedNetworkImage extends StatelessWidget {
 
   /// Widget displayed while the target [imageUrl] failed loading.
   final LoadingErrorWidgetBuilder? errorWidget;
+
+  /// Builder for images whose format is not supported by Flutter's standard
+  /// image codec (e.g. SVG).
+  ///
+  /// When set, the image is still downloaded and cached normally. If the
+  /// cached bytes cannot be decoded as a raster image, this builder is called
+  /// with the raw bytes so you can render them with a custom package such as
+  /// `flutter_svg`.
+  ///
+  /// If this is `null` and the image format is unsupported, the
+  /// [errorWidget] builder is called instead (with an
+  /// [UnsupportedImageFormatException]).
+  final UnsupportedImageWidgetBuilder? unsupportedImageBuilder;
 
   /// The duration of the fade-in animation for the [placeholder].
   final Duration? placeholderFadeInDuration;
@@ -216,6 +251,7 @@ class CachedNetworkImage extends StatelessWidget {
     this.placeholder,
     this.progressIndicatorBuilder,
     this.errorWidget,
+    this.unsupportedImageBuilder,
     this.fadeOutDuration = const Duration(milliseconds: 1000),
     this.fadeOutCurve = Curves.easeOut,
     this.fadeInDuration = const Duration(milliseconds: 500),
@@ -273,7 +309,7 @@ class CachedNetworkImage extends StatelessWidget {
       imageBuilder: imageBuilder != null ? _octoImageBuilder : null,
       placeholderBuilder: octoPlaceholderBuilder,
       progressIndicatorBuilder: octoProgressIndicatorBuilder,
-      errorBuilder: errorWidget != null ? _octoErrorBuilder : null,
+      errorBuilder: _octoErrorBuilder,
       fadeOutDuration: fadeOutDuration,
       fadeOutCurve: fadeOutCurve,
       fadeInDuration: fadeInDuration,
@@ -324,6 +360,13 @@ class CachedNetworkImage extends StatelessWidget {
     Object error,
     StackTrace? stackTrace,
   ) {
-    return errorWidget!(context, imageUrl, error);
+    if (error is UnsupportedImageFormatException &&
+        unsupportedImageBuilder != null) {
+      return unsupportedImageBuilder!(context, imageUrl, error.bytes);
+    }
+    if (errorWidget != null) {
+      return errorWidget!(context, imageUrl, error);
+    }
+    return const SizedBox.shrink();
   }
 }

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -120,6 +120,15 @@ class ImageLoader implements platform.ImageLoader {
         if (result is FileInfo) {
           final file = result.file;
           final bytes = await file.readAsBytes();
+          final unsupportedFormat =
+              ImageFormatDetector.detectUnsupportedFormat(bytes);
+          if (unsupportedFormat != null) {
+            throw UnsupportedImageFormatException(
+              bytes: bytes,
+              url: url,
+              detectedFormat: unsupportedFormat,
+            );
+          }
           final decoded = await decode(bytes);
           yield decoded;
         }

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,15 +7,15 @@ topics:
   - cache
   - image
   - network-image
-version: 4.1.1
+version: 4.2.0
 
 environment:
   sdk: ^3.0.0
   flutter: '>=3.10.0'
 
 dependencies:
-  cached_network_image_platform_interface_ce: ^5.0.1
-  cached_network_image_web_ce: ^2.0.1
+  cached_network_image_platform_interface_ce: ^5.1.0
+  cached_network_image_web_ce: ^2.1.0
   file: '>=7.0.0 <8.0.0'
   flutter:
     sdk: flutter

--- a/cached_network_image/test/image_format_detector_test.dart
+++ b/cached_network_image/test/image_format_detector_test.dart
@@ -1,0 +1,147 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cached_network_image_platform_interface_ce/src/image_format_detector.dart';
+import 'package:cached_network_image_platform_interface_ce/src/unsupported_image_format_exception.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ImageFormatDetector.isSvg', () {
+    test('detects simple <svg opening tag', () {
+      final bytes = utf8.encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isTrue);
+    });
+
+    test('detects <svg with leading whitespace', () {
+      final bytes = utf8.encode('   \n  <svg></svg>');
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isTrue);
+    });
+
+    test('detects <svg case-insensitively', () {
+      final bytes = utf8.encode('<SVG xmlns="http://www.w3.org/2000/svg"></SVG>');
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isTrue);
+    });
+
+    test('detects XML declaration followed by <svg', () {
+      final bytes = utf8.encode(
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+      );
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isTrue);
+    });
+
+    test('detects <!DOCTYPE svg', () {
+      final bytes = utf8.encode(
+        '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" '
+        '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n'
+        '<svg></svg>',
+      );
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isTrue);
+    });
+
+    test('detects SVG with UTF-8 BOM', () {
+      final svgBytes = utf8.encode('<svg></svg>');
+      final withBom = Uint8List.fromList([0xEF, 0xBB, 0xBF, ...svgBytes]);
+      expect(ImageFormatDetector.isSvg(withBom), isTrue);
+    });
+
+    test('detects XML with BOM followed by <svg', () {
+      final svgBytes = utf8.encode(
+        '<?xml version="1.0"?><svg></svg>',
+      );
+      final withBom = Uint8List.fromList([0xEF, 0xBB, 0xBF, ...svgBytes]);
+      expect(ImageFormatDetector.isSvg(withBom), isTrue);
+    });
+
+    test('returns false for empty bytes', () {
+      expect(ImageFormatDetector.isSvg(Uint8List(0)), isFalse);
+    });
+
+    test('returns false for PNG bytes', () {
+      final pngHeader = Uint8List.fromList(
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+      );
+      expect(ImageFormatDetector.isSvg(pngHeader), isFalse);
+    });
+
+    test('returns false for JPEG bytes', () {
+      final jpegHeader = Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xE0]);
+      expect(ImageFormatDetector.isSvg(jpegHeader), isFalse);
+    });
+
+    test('returns false for HTML content', () {
+      final bytes = utf8.encode(
+        '<!DOCTYPE html><html><body>not an svg</body></html>',
+      );
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isFalse);
+    });
+
+    test('returns false for XML without SVG', () {
+      final bytes = utf8.encode(
+        '<?xml version="1.0"?><root><child/></root>',
+      );
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isFalse);
+    });
+
+    test('returns false for just whitespace', () {
+      final bytes = utf8.encode('   \n\t  ');
+      expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isFalse);
+    });
+  });
+
+  group('ImageFormatDetector.detectUnsupportedFormat', () {
+    test('returns "svg" for SVG bytes', () {
+      final bytes = utf8.encode('<svg></svg>');
+      expect(
+        ImageFormatDetector.detectUnsupportedFormat(Uint8List.fromList(bytes)),
+        equals('svg'),
+      );
+    });
+
+    test('returns null for PNG bytes', () {
+      final pngHeader = Uint8List.fromList(
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+      );
+      expect(
+        ImageFormatDetector.detectUnsupportedFormat(pngHeader),
+        isNull,
+      );
+    });
+  });
+
+  group('UnsupportedImageFormatException', () {
+    test('toString includes URL and format', () {
+      final exception = UnsupportedImageFormatException(
+        bytes: Uint8List(0),
+        url: 'https://example.com/image.svg',
+        detectedFormat: 'svg',
+      );
+      final str = exception.toString();
+      expect(str, contains('https://example.com/image.svg'));
+      expect(str, contains('svg'));
+      expect(str, contains('unsupportedImageBuilder'));
+    });
+
+    test('toString works without detected format', () {
+      final exception = UnsupportedImageFormatException(
+        bytes: Uint8List(0),
+        url: 'https://example.com/image',
+      );
+      final str = exception.toString();
+      expect(str, contains('https://example.com/image'));
+      expect(str, isNot(contains('detected format')));
+    });
+
+    test('holds bytes and url correctly', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final exception = UnsupportedImageFormatException(
+        bytes: bytes,
+        url: 'https://example.com/test.svg',
+        detectedFormat: 'svg',
+      );
+      expect(exception.bytes, same(bytes));
+      expect(exception.url, 'https://example.com/test.svg');
+      expect(exception.detectedFormat, 'svg');
+    });
+  });
+}

--- a/cached_network_image/test/image_format_detector_test.dart
+++ b/cached_network_image/test/image_format_detector_test.dart
@@ -8,7 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('ImageFormatDetector.isSvg', () {
     test('detects simple <svg opening tag', () {
-      final bytes = utf8.encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+      final bytes =
+          utf8.encode('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
       expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isTrue);
     });
 
@@ -18,7 +19,8 @@ void main() {
     });
 
     test('detects <svg case-insensitively', () {
-      final bytes = utf8.encode('<SVG xmlns="http://www.w3.org/2000/svg"></SVG>');
+      final bytes =
+          utf8.encode('<SVG xmlns="http://www.w3.org/2000/svg"></SVG>');
       expect(ImageFormatDetector.isSvg(Uint8List.fromList(bytes)), isTrue);
     });
 

--- a/cached_network_image/test/svg_support_test.dart
+++ b/cached_network_image/test/svg_support_test.dart
@@ -36,8 +36,7 @@ void main() {
   });
 
   group('CachedNetworkImage SVG support', () {
-    testWidgets(
-        'unsupportedImageBuilder is called with SVG bytes',
+    testWidgets('unsupportedImageBuilder is called with SVG bytes',
         (tester) async {
       const imageUrl = 'svg-test';
       cacheManager.returns(imageUrl, kSvgImage);
@@ -95,8 +94,7 @@ void main() {
 
     testWidgets(
         'errorWidget receives UnsupportedImageFormatException when '
-        'unsupportedImageBuilder is null',
-        (tester) async {
+        'unsupportedImageBuilder is null', (tester) async {
       const imageUrl = 'svg-error-fallback-test';
       cacheManager.returns(imageUrl, kSvgImage);
       Object? receivedError;
@@ -121,8 +119,7 @@ void main() {
       expect(find.text('Error fallback'), findsOneWidget);
     });
 
-    testWidgets(
-        'regular raster image does not trigger unsupportedImageBuilder',
+    testWidgets('regular raster image does not trigger unsupportedImageBuilder',
         (tester) async {
       const imageUrl = 'raster-image-test';
       cacheManager.returns(imageUrl, kTransparentImage);

--- a/cached_network_image/test/svg_support_test.dart
+++ b/cached_network_image/test/svg_support_test.dart
@@ -1,0 +1,210 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_cache_manager.dart';
+import 'image_data.dart';
+
+/// Minimal SVG content for testing.
+final List<int> kSvgImage = utf8.encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+  '<rect width="1" height="1" fill="red"/>'
+  '</svg>',
+);
+
+/// SVG with XML declaration header.
+final List<int> kSvgWithXmlDeclaration = utf8.encode(
+  '<?xml version="1.0" encoding="UTF-8"?>\n'
+  '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1">'
+  '<rect width="1" height="1" fill="blue"/>'
+  '</svg>',
+);
+
+void main() {
+  late FakeCacheManager cacheManager;
+
+  setUp(() {
+    cacheManager = FakeCacheManager();
+  });
+
+  tearDown(() {
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
+  });
+
+  group('CachedNetworkImage SVG support', () {
+    testWidgets(
+        'unsupportedImageBuilder is called with SVG bytes',
+        (tester) async {
+      const imageUrl = 'svg-test';
+      cacheManager.returns(imageUrl, kSvgImage);
+      Uint8List? receivedBytes;
+      String? receivedUrl;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              unsupportedImageBuilder: (context, url, bytes) {
+                receivedBytes = bytes;
+                receivedUrl = url;
+                return const Text('SVG rendered');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(receivedUrl, imageUrl);
+      expect(receivedBytes, isNotNull);
+      // Verify the bytes contain SVG content.
+      final content = utf8.decode(receivedBytes!);
+      expect(content, contains('<svg'));
+      expect(find.text('SVG rendered'), findsOneWidget);
+    });
+
+    testWidgets(
+        'unsupportedImageBuilder is called for SVG with XML declaration',
+        (tester) async {
+      const imageUrl = 'svg-xml-decl-test';
+      cacheManager.returns(imageUrl, kSvgWithXmlDeclaration);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              unsupportedImageBuilder: (context, url, bytes) {
+                return const Text('XML SVG rendered');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('XML SVG rendered'), findsOneWidget);
+    });
+
+    testWidgets(
+        'errorWidget receives UnsupportedImageFormatException when '
+        'unsupportedImageBuilder is null',
+        (tester) async {
+      const imageUrl = 'svg-error-fallback-test';
+      cacheManager.returns(imageUrl, kSvgImage);
+      Object? receivedError;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              errorWidget: (context, url, error) {
+                receivedError = error;
+                return const Text('Error fallback');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(receivedError, isA<UnsupportedImageFormatException>());
+      expect(find.text('Error fallback'), findsOneWidget);
+    });
+
+    testWidgets(
+        'regular raster image does not trigger unsupportedImageBuilder',
+        (tester) async {
+      const imageUrl = 'raster-image-test';
+      cacheManager.returns(imageUrl, kTransparentImage);
+      var unsupportedCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              unsupportedImageBuilder: (context, url, bytes) {
+                unsupportedCalled = true;
+                return const Text('Should not appear');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(unsupportedCalled, isFalse);
+      expect(find.text('Should not appear'), findsNothing);
+    });
+
+    testWidgets(
+        'unsupportedImageBuilder takes precedence over errorWidget for SVGs',
+        (tester) async {
+      const imageUrl = 'svg-precedence-test';
+      cacheManager.returns(imageUrl, kSvgImage);
+      var errorCalled = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              unsupportedImageBuilder: (context, url, bytes) {
+                return const Text('SVG handler');
+              },
+              errorWidget: (context, url, error) {
+                errorCalled = true;
+                return const Text('Error handler');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(errorCalled, isFalse);
+      expect(find.text('SVG handler'), findsOneWidget);
+      expect(find.text('Error handler'), findsNothing);
+    });
+
+    testWidgets(
+        'errorWidget still works for non-SVG errors when unsupportedImageBuilder is set',
+        (tester) async {
+      const imageUrl = 'non-svg-error-test';
+      cacheManager.throwsNotFound(imageUrl);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              unsupportedImageBuilder: (context, url, bytes) {
+                return const Text('Should not appear');
+              },
+              errorWidget: (context, url, error) {
+                return const Text('404 error');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('404 error'), findsOneWidget);
+      expect(find.text('Should not appear'), findsNothing);
+    });
+  });
+}

--- a/cached_network_image_platform_interface/CHANGELOG.md
+++ b/cached_network_image_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.1.0] - 2026-02-23
+
+* **Feature:** Added `UnsupportedImageFormatException` for non-codec-decodable formats (e.g., SVG)
+* **Feature:** Added `ImageFormatDetector` utility with SVG content sniffing
+* Exported new types for use by platform implementations
+
 ## [5.0.1] - 2026-02-19
 
 * Renamed package to `cached_network_image_platform_interface_ce`

--- a/cached_network_image_platform_interface/lib/cached_network_image_platform_interface_ce.dart
+++ b/cached_network_image_platform_interface/lib/cached_network_image_platform_interface_ce.dart
@@ -11,6 +11,8 @@ import 'src/cache_manager.dart';
 export 'src/cache_manager.dart';
 export 'src/file_response.dart';
 export 'src/http_exception.dart';
+export 'src/image_format_detector.dart';
+export 'src/unsupported_image_format_exception.dart';
 
 /// Listener for errors
 typedef ErrorListener = void Function(Object);

--- a/cached_network_image_platform_interface/lib/src/image_format_detector.dart
+++ b/cached_network_image_platform_interface/lib/src/image_format_detector.dart
@@ -1,0 +1,50 @@
+import 'dart:typed_data';
+
+/// Utility to detect image formats that are not supported by Flutter's
+/// standard image codec (e.g. SVG).
+class ImageFormatDetector {
+  ImageFormatDetector._();
+
+  /// Returns `true` if [bytes] appear to be an SVG image.
+  ///
+  /// Checks the first bytes of the content (up to 1024 bytes) for SVG
+  /// signatures: `<svg`, `<?xml`, or `<!DOCTYPE svg`.
+  /// Also handles a leading UTF-8 BOM (`0xEF 0xBB 0xBF`).
+  static bool isSvg(Uint8List bytes) {
+    if (bytes.isEmpty) return false;
+
+    var start = 0;
+
+    // Strip UTF-8 BOM if present.
+    if (bytes.length >= 3 &&
+        bytes[0] == 0xEF &&
+        bytes[1] == 0xBB &&
+        bytes[2] == 0xBF) {
+      start = 3;
+    }
+
+    // Only inspect the first ~1024 bytes for performance.
+    final end = bytes.length < 1024 ? bytes.length : 1024;
+    final header = String.fromCharCodes(bytes, start, end).trimLeft();
+    final lower = header.toLowerCase();
+
+    if (lower.startsWith('<svg')) return true;
+    if (lower.startsWith('<?xml')) {
+      // XML declaration — check if the body contains <svg within the header.
+      return lower.contains('<svg');
+    }
+    if (lower.startsWith('<!doctype svg')) return true;
+
+    return false;
+  }
+
+  /// Returns the detected format name for [bytes], or `null` if the format
+  /// is supported by Flutter's standard codec.
+  ///
+  /// Currently only detects SVG. Can be extended for other unsupported
+  /// formats in the future.
+  static String? detectUnsupportedFormat(Uint8List bytes) {
+    if (isSvg(bytes)) return 'svg';
+    return null;
+  }
+}

--- a/cached_network_image_platform_interface/lib/src/unsupported_image_format_exception.dart
+++ b/cached_network_image_platform_interface/lib/src/unsupported_image_format_exception.dart
@@ -1,0 +1,33 @@
+import 'dart:typed_data';
+
+/// Exception thrown when the image bytes cannot be decoded by Flutter's
+/// standard image codec (e.g. SVG images).
+///
+/// When caught, the [bytes] field contains the raw cached file bytes so that
+/// a custom renderer (such as `flutter_svg`) can display the image.
+class UnsupportedImageFormatException implements Exception {
+  /// Creates an [UnsupportedImageFormatException].
+  const UnsupportedImageFormatException({
+    required this.bytes,
+    required this.url,
+    this.detectedFormat,
+  });
+
+  /// The raw bytes of the cached file.
+  final Uint8List bytes;
+
+  /// The original URL of the image.
+  final String url;
+
+  /// The detected image format, e.g. `"svg"`, if known.
+  final String? detectedFormat;
+
+  @override
+  String toString() {
+    final format =
+        detectedFormat != null ? ' (detected format: $detectedFormat)' : '';
+    return 'UnsupportedImageFormatException: '
+        'Image at "$url" could not be decoded by the standard codec$format. '
+        'Use unsupportedImageBuilder to supply a custom renderer.';
+  }
+}

--- a/cached_network_image_platform_interface/pubspec.yaml
+++ b/cached_network_image_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_network_image_platform_interface_ce
 description: Platform interface for CachedNetworkImage (Community Edition)
-version: 5.0.1
+version: 5.1.0
 homepage: https://github.com/Erengun/flutter_cached_network_image_ce
 repository: https://github.com/Erengun/flutter_cached_network_image_ce/tree/develop/cached_network_image_platform_interface
 topics:

--- a/cached_network_image_web/CHANGELOG.md
+++ b/cached_network_image_web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.1.0] - 2026-02-23
+
+* **Feature:** Added SVG format detection in `HttpGet` loader path
+* Updated to use `ImageFormatDetector` from platform interface 5.1.0
+* Throws `UnsupportedImageFormatException` for SVG bytes before decoding
+
 ## [2.0.1] - 2026-02-19
 
 * Renamed package to `cached_network_image_web_ce`

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -147,8 +147,18 @@ class ImageLoader implements platform.ImageLoader {
 
             event.file
                 .readAsBytes()
-                .then((value) => decode(value))
-                .then((data) {
+                .then((value) {
+              final unsupportedFormat =
+                  ImageFormatDetector.detectUnsupportedFormat(value);
+              if (unsupportedFormat != null) {
+                throw UnsupportedImageFormatException(
+                  bytes: value,
+                  url: url,
+                  detectedFormat: unsupportedFormat,
+                );
+              }
+              return decode(value);
+            }).then((data) {
               streamController.add(data);
               if (state == _State.closing) {
                 streamController.close();

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -145,9 +145,7 @@ class ImageLoader implements platform.ImageLoader {
               state = _State.waitingForData;
             }
 
-            event.file
-                .readAsBytes()
-                .then((value) {
+            event.file.readAsBytes().then((value) {
               final unsupportedFormat =
                   ImageFormatDetector.detectUnsupportedFormat(value);
               if (unsupportedFormat != null) {

--- a/cached_network_image_web/pubspec.yaml
+++ b/cached_network_image_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_network_image_web_ce
 description: Web implementation of CachedNetworkImage (Community Edition)
-version: 2.0.1
+version: 2.1.0
 homepage: https://github.com/Erengun/flutter_cached_network_image_ce
 repository: https://github.com/Erengun/flutter_cached_network_image_ce/tree/develop/cached_network_image_web
 topics:
@@ -13,7 +13,7 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  cached_network_image_platform_interface_ce: ^5.0.1
+  cached_network_image_platform_interface_ce: ^5.1.0
   flutter:
     sdk: flutter
   web: ^1.0.0


### PR DESCRIPTION
## Description

Introduce SVG format detection and handling in the image loading process. Implement an `ImageFormatDetector` utility to identify unsupported formats, specifically SVG. Add an `UnsupportedImageFormatException` for cases where the image format cannot be decoded by Flutter's standard codec. Update the example project to demonstrate SVG usage and include comprehensive tests for the new functionality.

## Related Issues

https://github.com/Baseflow/flutter_cached_network_image/issues/383

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SVG support via an unsupportedImageBuilder callback, plus automatic format detection and a new exception for non-decodable image formats; caching behavior unchanged.

* **Documentation**
  * README updated with an SVG support guide and usage examples.

* **Tests**
  * New unit and widget tests covering format detection and SVG handling.

* **Example**
  * Example app updated to demonstrate SVG usage (adds SVG dependency).

* **Chores**
  * CI/devtools metadata and a setup script added to enable local dependency overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->