### PR TITLE
Fix memory leak in CachedNetworkImage and improve error handling

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.3.0] - 2026-02-26
+
+* **Feature/Deprecation:** Added `errorBuilder` to `CachedNetworkImage` and `CachedImageWidget`, which aligns with Flutter's standard `ImageErrorWidgetBuilder`. The old `errorWidget` property is now deprecated.
+* **Fix:** Resolved a memory leak where `errorListener` would prevent `CachedNetworkImage` from being garbage collected. Uses `addEphemeralErrorListener` on Flutter >= 3.16.
+
 ## [4.2.0] - 2026-02-23
 
 * **Feature:** Added SVG support via new `unsupportedImageBuilder` callback

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -83,7 +83,7 @@ class BasicContent extends StatelessWidget {
                   bytes,
                   fit: BoxFit.contain,
                 ),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
               ),
             ),
             _sizedContainer(
@@ -134,7 +134,7 @@ class BasicContent extends StatelessWidget {
                 ),
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
               ),
             ),
             CachedNetworkImage(
@@ -151,10 +151,12 @@ class BasicContent extends StatelessWidget {
             ),
             _sizedContainer(
               CachedNetworkImage(
-                imageUrl: 'https://notAvalid.uri',
+                errorBuilder: (context, error, stackTrace) =>
+                    const Icon(Icons.error),
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                imageUrl:
+                    'not a valid uri',
               ),
             ),
             _sizedContainer(
@@ -162,7 +164,7 @@ class BasicContent extends StatelessWidget {
                 imageUrl: 'not a uri at all',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
                 errorListener: (e) {
                   if (e is SocketException) {
                     debugPrint(
@@ -180,7 +182,7 @@ class BasicContent extends StatelessWidget {
                     'https://images.unsplash.com/photo-1706212074955-6045fce2521d?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                errorWidget: (context, url, error) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
                 fadeInDuration: const Duration(seconds: 3),
               ),
             ),
@@ -253,7 +255,7 @@ class GridContent extends StatelessWidget {
       itemBuilder: (BuildContext context, int index) => CachedNetworkImage(
         imageUrl: 'https://loremflickr.com/100/100/music?lock=$index',
         placeholder: _loader,
-        errorWidget: _error,
+        errorBuilder: _error,
       ),
     );
   }
@@ -262,7 +264,7 @@ class GridContent extends StatelessWidget {
     return const Center(child: CircularProgressIndicator());
   }
 
-  Widget _error(BuildContext context, String url, Object error) {
+  Widget _error(BuildContext context, Object error, StackTrace? stackTrace) {
     return const Center(child: Icon(Icons.error));
   }
 }

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -83,7 +83,8 @@ class BasicContent extends StatelessWidget {
                   bytes,
                   fit: BoxFit.contain,
                 ),
-                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) =>
+                    const Icon(Icons.error),
               ),
             ),
             _sizedContainer(
@@ -134,7 +135,8 @@ class BasicContent extends StatelessWidget {
                 ),
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) =>
+                    const Icon(Icons.error),
               ),
             ),
             CachedNetworkImage(
@@ -155,8 +157,7 @@ class BasicContent extends StatelessWidget {
                     const Icon(Icons.error),
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                imageUrl:
-                    'not a valid uri',
+                imageUrl: 'not a valid uri',
               ),
             ),
             _sizedContainer(
@@ -164,7 +165,8 @@ class BasicContent extends StatelessWidget {
                 imageUrl: 'not a uri at all',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) =>
+                    const Icon(Icons.error),
                 errorListener: (e) {
                   if (e is SocketException) {
                     debugPrint(
@@ -182,7 +184,8 @@ class BasicContent extends StatelessWidget {
                     'https://images.unsplash.com/photo-1706212074955-6045fce2521d?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
                 placeholder: (context, url) =>
                     const CircularProgressIndicator(),
-                errorBuilder: (context, error, stackTrace) => const Icon(Icons.error),
+                errorBuilder: (context, error, stackTrace) =>
+                    const Icon(Icons.error),
                 fadeInDuration: const Duration(seconds: 3),
               ),
             ),

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -254,8 +254,7 @@ class CachedNetworkImage extends StatelessWidget {
     this.imageBuilder,
     this.placeholder,
     this.progressIndicatorBuilder,
-    @Deprecated('Use errorBuilder instead.')
-    this.errorWidget,
+    @Deprecated('Use errorBuilder instead.') this.errorWidget,
     this.errorBuilder,
     this.unsupportedImageBuilder,
     this.fadeOutDuration = const Duration(milliseconds: 1000),

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -103,7 +103,11 @@ class CachedNetworkImage extends StatelessWidget {
   final ProgressIndicatorBuilder? progressIndicatorBuilder;
 
   /// Widget displayed while the target [imageUrl] failed loading.
+  @Deprecated('Use errorBuilder instead.')
   final LoadingErrorWidgetBuilder? errorWidget;
+
+  /// Builder displayed while the target [imageUrl] failed loading.
+  final ImageErrorWidgetBuilder? errorBuilder;
 
   /// Builder for images whose format is not supported by Flutter's standard
   /// image codec (e.g. SVG).
@@ -250,7 +254,9 @@ class CachedNetworkImage extends StatelessWidget {
     this.imageBuilder,
     this.placeholder,
     this.progressIndicatorBuilder,
+    @Deprecated('Use errorBuilder instead.')
     this.errorWidget,
+    this.errorBuilder,
     this.unsupportedImageBuilder,
     this.fadeOutDuration = const Duration(milliseconds: 1000),
     this.fadeOutCurve = Curves.easeOut,
@@ -299,6 +305,7 @@ class CachedNetworkImage extends StatelessWidget {
         placeholder != null ||
         progressIndicatorBuilder != null ||
         errorWidget != null ||
+        errorBuilder != null ||
         unsupportedImageBuilder != null;
 
     ///If there is no placeholder OctoImage does not fade, so always set an
@@ -368,6 +375,9 @@ class CachedNetworkImage extends StatelessWidget {
     if (error is UnsupportedImageFormatException &&
         unsupportedImageBuilder != null) {
       return unsupportedImageBuilder!(context, imageUrl, error.bytes);
+    }
+    if (errorBuilder != null) {
+      return errorBuilder!(context, error, stackTrace);
     }
     if (errorWidget != null) {
       return errorWidget!(context, imageUrl, error);

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -46,6 +46,10 @@ class CachedNetworkImageProvider
   final double scale;
 
   /// Listener to be called when images fails to load.
+  ///
+  /// Note: Using this listener with Flutter versions older than 3.16 may
+  /// cause a memory leak if the image fails to load. Please upgrade Flutter
+  /// to avoid this issue.
   final ErrorListener? errorListener;
 
   /// Set headers for the image provider, for example for authentication
@@ -87,14 +91,30 @@ class CachedNetworkImageProvider
     );
 
     if (errorListener != null) {
-      imageStreamCompleter.addListener(
-        ImageStreamListener(
-          (image, synchronousCall) {},
-          onError: (Object error, StackTrace? trace) {
+      // In Flutter >= 3.16, we use addEphemeralErrorListener to avoid memory leaks.
+      // addListener keeps the ImageStreamCompleter alive, which prevents disposal
+      // when there are no other active listeners.
+      try {
+        (imageStreamCompleter as dynamic).addEphemeralErrorListener(
+          (Object error, StackTrace? trace) {
             errorListener?.call(error);
           },
-        ),
-      );
+        );
+      } on NoSuchMethodError {
+        assert(
+          false,
+          'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
+          'Please upgrade Flutter or avoid using errorListener.',
+        );
+        imageStreamCompleter.addListener(
+          ImageStreamListener(
+            (image, synchronousCall) {},
+            onError: (Object error, StackTrace? trace) {
+              errorListener?.call(error);
+            },
+          ),
+        );
+      }
     }
 
     return imageStreamCompleter;
@@ -138,14 +158,30 @@ class CachedNetworkImageProvider
     );
 
     if (errorListener != null) {
-      imageStreamCompleter.addListener(
-        ImageStreamListener(
-          (image, synchronousCall) {},
-          onError: (Object error, StackTrace? trace) {
+      // In Flutter >= 3.16, we use addEphemeralErrorListener to avoid memory leaks.
+      // addListener keeps the ImageStreamCompleter alive, which prevents disposal
+      // when there are no other active listeners.
+      try {
+        (imageStreamCompleter as dynamic).addEphemeralErrorListener(
+          (Object error, StackTrace? trace) {
             errorListener?.call(error);
           },
-        ),
-      );
+        );
+      } on NoSuchMethodError {
+        assert(
+          false,
+          'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
+          'Please upgrade Flutter or avoid using errorListener.',
+        );
+        imageStreamCompleter.addListener(
+          ImageStreamListener(
+            (image, synchronousCall) {},
+            onError: (Object error, StackTrace? trace) {
+              errorListener?.call(error);
+            },
+          ),
+        );
+      }
     }
 
     return imageStreamCompleter;

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -101,10 +101,15 @@ class CachedNetworkImageProvider
           },
         );
       } on NoSuchMethodError {
-        assert(
-          false,
-          'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
-          'Please upgrade Flutter or avoid using errorListener.',
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: 'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
+                'Please upgrade Flutter or avoid using errorListener.',
+            library: 'cached_network_image',
+            context: ErrorDescription(
+              'CachedNetworkImageProvider.loadBuffer fallback to addListener',
+            ),
+          ),
         );
         imageStreamCompleter.addListener(
           ImageStreamListener(
@@ -168,10 +173,15 @@ class CachedNetworkImageProvider
           },
         );
       } on NoSuchMethodError {
-        assert(
-          false,
-          'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
-          'Please upgrade Flutter or avoid using errorListener.',
+        FlutterError.reportError(
+          FlutterErrorDetails(
+            exception: 'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
+                'Please upgrade Flutter or avoid using errorListener.',
+            library: 'cached_network_image',
+            context: ErrorDescription(
+              'CachedNetworkImageProvider.loadImage fallback to addListener',
+            ),
+          ),
         );
         imageStreamCompleter.addListener(
           ImageStreamListener(

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -103,7 +103,8 @@ class CachedNetworkImageProvider
       } on NoSuchMethodError {
         FlutterError.reportError(
           FlutterErrorDetails(
-            exception: 'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
+            exception:
+                'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
                 'Please upgrade Flutter or avoid using errorListener.',
             library: 'cached_network_image',
             context: ErrorDescription(
@@ -175,7 +176,8 @@ class CachedNetworkImageProvider
       } on NoSuchMethodError {
         FlutterError.reportError(
           FlutterErrorDetails(
-            exception: 'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
+            exception:
+                'Warning: Using errorListener with Flutter < 3.16 causes memory leaks. '
                 'Please upgrade Flutter or avoid using errorListener.',
             library: 'cached_network_image',
             context: ErrorDescription(

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.2.0
+version: 4.3.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/leak_test.dart
+++ b/cached_network_image/test/leak_test.dart
@@ -528,7 +528,9 @@ void main() {
       PaintingBinding.instance.imageCache.evict(provider);
     });
 
-    testWidgets('errorListener does not leak ImageStreamCompleter on Flutter >= 3.16', (tester) async {
+    testWidgets(
+        'errorListener does not leak ImageStreamCompleter on Flutter >= 3.16',
+        (tester) async {
       const url = 'https://example.com/buffer-error-listener-leak.png';
       fakeCacheManager.throwsNotFound(url);
 
@@ -551,19 +553,20 @@ void main() {
       );
 
       expect(completer, isA<ImageStreamCompleter>());
-      
+
       // Add a listener
       final listener = ImageStreamListener((image, synchronousCall) {});
       completer.addListener(listener);
-      
+
       await tester.pump();
-      
+
       // Remove the listener
       completer.removeListener(listener);
-      
-      // If addEphemeralErrorListener works correctly, the completer should report 0 active listeners 
+
+      // If addEphemeralErrorListener works correctly, the completer should report 0 active listeners
       // when no standard ImageStreamListeners are attached.
-      expect(completer.hasListeners, isFalse, reason: 'errorListener should not keep the completer alive');
+      expect(completer.hasListeners, isFalse,
+          reason: 'errorListener should not keep the completer alive');
     });
   });
 

--- a/cached_network_image/test/leak_test.dart
+++ b/cached_network_image/test/leak_test.dart
@@ -454,6 +454,7 @@ void main() {
       // Suppress expected image codec error from reportError
       final originalOnError = FlutterError.onError;
       FlutterError.onError = (details) {};
+      addTearDown(() => FlutterError.onError = originalOnError);
 
       final provider = CachedNetworkImageProvider(
         url,
@@ -471,8 +472,6 @@ void main() {
 
       expect(completer, isA<ImageStreamCompleter>());
       await tester.pump();
-
-      FlutterError.onError = originalOnError;
     });
 
     testWidgets('loadBuffer cleans up on error without errorListener',
@@ -483,6 +482,7 @@ void main() {
       // Suppress expected image codec error from reportError
       final originalOnError = FlutterError.onError;
       FlutterError.onError = (details) {};
+      addTearDown(() => FlutterError.onError = originalOnError);
 
       final provider = CachedNetworkImageProvider(
         url,
@@ -501,8 +501,6 @@ void main() {
 
       expect(completer, isA<ImageStreamCompleter>());
       await tester.pump();
-
-      FlutterError.onError = originalOnError;
     });
 
     testWidgets('evictFromCache does not leak', (tester) async {
@@ -528,6 +526,44 @@ void main() {
 
       // Evict from cache — should clean up without leaking
       PaintingBinding.instance.imageCache.evict(provider);
+    });
+
+    testWidgets('errorListener does not leak ImageStreamCompleter on Flutter >= 3.16', (tester) async {
+      const url = 'https://example.com/buffer-error-listener-leak.png';
+      fakeCacheManager.throwsNotFound(url);
+
+      final originalOnError = FlutterError.onError;
+      FlutterError.onError = (details) {};
+      addTearDown(() => FlutterError.onError = originalOnError);
+
+      final provider = CachedNetworkImageProvider(
+        url,
+        cacheManager: fakeCacheManager,
+        errorListener: (e) {},
+      );
+
+      final completer = provider.loadImage(
+        provider,
+        (ui.ImmutableBuffer buffer,
+            {ui.TargetImageSizeCallback? getTargetSize}) async {
+          return await ui.instantiateImageCodecFromBuffer(buffer);
+        },
+      );
+
+      expect(completer, isA<ImageStreamCompleter>());
+      
+      // Add a listener
+      final listener = ImageStreamListener((image, synchronousCall) {});
+      completer.addListener(listener);
+      
+      await tester.pump();
+      
+      // Remove the listener
+      completer.removeListener(listener);
+      
+      // If addEphemeralErrorListener works correctly, the completer should report 0 active listeners 
+      // when no standard ImageStreamListeners are attached.
+      expect(completer.hasListeners, isFalse, reason: 'errorListener should not keep the completer alive');
     });
   });
 


### PR DESCRIPTION
## Description

Introduce `errorBuilder` with `StackTrace` for `CachedNetworkImage` to enhance error handling and prevent memory leaks associated with the `errorListener` by using `addEphemeralErrorListener`. Deprecate the `errorWidget` in favor of the new `errorBuilder`. Update tests to ensure proper cleanup and prevent leaks. 

## Related Issues

Fixes 
https://github.com/Baseflow/flutter_cached_network_image/issues/938
Part of
https://github.com/Baseflow/flutter_cached_network_image/issues/429

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new errorBuilder parameter for image error rendering; errorWidget is now deprecated.

* **Bug Fixes**
  * Prevented memory leaks from image error listeners on newer Flutter versions.

* **Tests**
  * Added tests to ensure error listener cleanup and prevent completer leaks.

* **Chores**
  * Bumped package version to 4.3.0 and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->