### PR TITLE
Skip placeholder and fade animations for cached images

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [4.4.0] - 2026-02-27
+
+* **Feature:** Skip placeholder and fade animations when images are loaded from disk cache. Cached images now appear instantly without unnecessary visual flicker.
+* Added `disablePlaceholderOnCacheHit` parameter (default `true`) to opt out of this behavior.
+* `CachedNetworkImage` is now a `StatefulWidget` to support async cache pre-checking.
+
 ## [4.3.0] - 2026-02-26
 
 * **Feature/Deprecation:** Added `errorBuilder` to `CachedNetworkImage` and `CachedImageWidget`, which aligns with Flutter's standard `ImageErrorWidgetBuilder`. The old `errorWidget` property is now deprecated.

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -312,6 +312,10 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
   /// flips to `false` and the placeholder appears via [setState].
   bool _skipPlaceholder = false;
 
+  /// Incremented each time [_preCheckCache] is called so that stale async
+  /// completions (from a previous URL or config) are discarded.
+  int _preCheckGeneration = 0;
+
   @override
   void initState() {
     super.initState();
@@ -326,7 +330,7 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
   void didUpdateWidget(CachedNetworkImage oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (oldWidget.imageUrl != widget.imageUrl ||
+    final imageConfigChanged = oldWidget.imageUrl != widget.imageUrl ||
         oldWidget.cacheKey != widget.cacheKey ||
         oldWidget.cacheManager != widget.cacheManager ||
         oldWidget.httpHeaders != widget.httpHeaders ||
@@ -334,9 +338,15 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
         oldWidget.maxHeightDiskCache != widget.maxHeightDiskCache ||
         oldWidget.imageRenderMethodForWeb != widget.imageRenderMethodForWeb ||
         oldWidget.scale != widget.scale ||
-        oldWidget.errorListener != widget.errorListener) {
-      _createImageProvider();
+        oldWidget.errorListener != widget.errorListener;
 
+    if (imageConfigChanged) {
+      _createImageProvider();
+    }
+
+    if (imageConfigChanged ||
+        oldWidget.disablePlaceholderOnCacheHit !=
+            widget.disablePlaceholderOnCacheHit) {
       if (widget.disablePlaceholderOnCacheHit) {
         _skipPlaceholder = true;
         _preCheckCache();
@@ -361,15 +371,18 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
   }
 
   Future<void> _preCheckCache() async {
+    final generation = ++_preCheckGeneration;
     final cm =
         widget.cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
     try {
       final cached =
           await cm.getFileFromCache(widget.cacheKey ?? widget.imageUrl);
+      if (generation != _preCheckGeneration) return;
       if (mounted && cached == null) {
         setState(() => _skipPlaceholder = false);
       }
     } on Object catch (_) {
+      if (generation != _preCheckGeneration) return;
       // If the cache check fails, fall back to showing the placeholder.
       if (mounted) {
         setState(() => _skipPlaceholder = false);

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -58,7 +58,7 @@ typedef UnsupportedImageWidgetBuilder = Widget Function(
 );
 
 /// Image widget to show NetworkImage with caching functionality.
-class CachedNetworkImage extends StatelessWidget {
+class CachedNetworkImage extends StatefulWidget {
   /// Get the current log level of the cache manager.
   static CacheManagerLogLevel get logLevel => CacheManager.logLevel;
 
@@ -81,8 +81,6 @@ class CachedNetworkImage extends StatelessWidget {
     await effectiveCacheManager.removeFile(cacheKey ?? url);
     return CachedNetworkImageProvider(url, scale: scale).evict();
   }
-
-  final CachedNetworkImageProvider _image;
 
   /// Option to use cacheManager with other settings
   final BaseCacheManager? cacheManager;
@@ -243,11 +241,26 @@ class CachedNetworkImage extends StatelessWidget {
   /// Listener to be called when images fails to load.
   final ValueChanged<Object>? errorListener;
 
+  /// Render option for images on the web platform.
+  final ImageRenderMethodForWeb imageRenderMethodForWeb;
+
+  /// Scale of the image.
+  final double scale;
+
+  /// When true (the default), the placeholder and fade-in/out animations are
+  /// skipped when the image is already available in the disk cache. This
+  /// prevents an unnecessary visual flicker for images that load almost
+  /// instantly from cache.
+  ///
+  /// Set to `false` to always show the placeholder and fade animations,
+  /// regardless of cache status.
+  final bool disablePlaceholderOnCacheHit;
+
   /// CachedNetworkImage shows a network image using a caching mechanism. It also
   /// provides support for a placeholder, showing an error and fading into the
   /// loaded image. Next to that it supports most features of a default Image
   /// widget.
-  CachedNetworkImage({
+  const CachedNetworkImage({
     super.key,
     required this.imageUrl,
     this.httpHeaders,
@@ -279,74 +292,163 @@ class CachedNetworkImage extends StatelessWidget {
     this.maxWidthDiskCache,
     this.maxHeightDiskCache,
     this.errorListener,
-    ImageRenderMethodForWeb imageRenderMethodForWeb =
-        ImageRenderMethodForWeb.HtmlImage,
-    double scale = 1.0,
-  }) : _image = CachedNetworkImageProvider(
-          imageUrl,
-          headers: httpHeaders,
-          cacheManager: cacheManager,
-          cacheKey: cacheKey,
-          imageRenderMethodForWeb: imageRenderMethodForWeb,
-          maxWidth: maxWidthDiskCache,
-          maxHeight: maxHeightDiskCache,
-          errorListener: errorListener,
-          scale: scale,
-        );
+    this.imageRenderMethodForWeb = ImageRenderMethodForWeb.HtmlImage,
+    this.scale = 1.0,
+    this.disablePlaceholderOnCacheHit = true,
+  });
+
+  @override
+  State<CachedNetworkImage> createState() => _CachedNetworkImageState();
+}
+
+class _CachedNetworkImageState extends State<CachedNetworkImage> {
+  late CachedNetworkImageProvider _image;
+
+  /// Whether the placeholder should be suppressed because the image is
+  /// available in the disk cache (and will load almost instantly).
+  ///
+  /// Starts as `true` (optimistic) when [disablePlaceholderOnCacheHit] is
+  /// enabled. If the async cache check reveals the image is NOT cached, this
+  /// flips to `false` and the placeholder appears via [setState].
+  bool _skipPlaceholder = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _createImageProvider();
+    if (widget.disablePlaceholderOnCacheHit) {
+      _skipPlaceholder = true;
+      _preCheckCache();
+    }
+  }
+
+  @override
+  void didUpdateWidget(CachedNetworkImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.imageUrl != widget.imageUrl ||
+        oldWidget.cacheKey != widget.cacheKey ||
+        oldWidget.cacheManager != widget.cacheManager ||
+        oldWidget.httpHeaders != widget.httpHeaders ||
+        oldWidget.maxWidthDiskCache != widget.maxWidthDiskCache ||
+        oldWidget.maxHeightDiskCache != widget.maxHeightDiskCache ||
+        oldWidget.imageRenderMethodForWeb != widget.imageRenderMethodForWeb ||
+        oldWidget.scale != widget.scale ||
+        oldWidget.errorListener != widget.errorListener) {
+      _createImageProvider();
+
+      if (widget.disablePlaceholderOnCacheHit) {
+        _skipPlaceholder = true;
+        _preCheckCache();
+      } else {
+        _skipPlaceholder = false;
+      }
+    }
+  }
+
+  void _createImageProvider() {
+    _image = CachedNetworkImageProvider(
+      widget.imageUrl,
+      headers: widget.httpHeaders,
+      cacheManager: widget.cacheManager,
+      cacheKey: widget.cacheKey,
+      imageRenderMethodForWeb: widget.imageRenderMethodForWeb,
+      maxWidth: widget.maxWidthDiskCache,
+      maxHeight: widget.maxHeightDiskCache,
+      errorListener: widget.errorListener,
+      scale: widget.scale,
+    );
+  }
+
+  Future<void> _preCheckCache() async {
+    final cm =
+        widget.cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
+    try {
+      final cached =
+          await cm.getFileFromCache(widget.cacheKey ?? widget.imageUrl);
+      if (mounted && cached == null) {
+        setState(() => _skipPlaceholder = false);
+      }
+    } on Object catch (_) {
+      // If the cache check fails, fall back to showing the placeholder.
+      if (mounted) {
+        setState(() => _skipPlaceholder = false);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    var octoPlaceholderBuilder =
-        placeholder != null ? _octoPlaceholderBuilder : null;
-    final octoProgressIndicatorBuilder =
-        progressIndicatorBuilder != null ? _octoProgressIndicatorBuilder : null;
-    final hasCustomBuilder = imageBuilder != null ||
-        placeholder != null ||
-        progressIndicatorBuilder != null ||
-        errorWidget != null ||
-        errorBuilder != null ||
-        unsupportedImageBuilder != null;
+    final hasCustomBuilder = widget.imageBuilder != null ||
+        widget.placeholder != null ||
+        widget.progressIndicatorBuilder != null ||
+        widget.errorWidget != null ||
+        widget.errorBuilder != null ||
+        widget.unsupportedImageBuilder != null;
 
-    ///If there is no placeholder OctoImage does not fade, so always set an
-    ///(empty) placeholder as this always used to be the behaviour of
-    ///CachedNetworkImage.
-    if (octoPlaceholderBuilder == null &&
-        octoProgressIndicatorBuilder == null) {
-      octoPlaceholderBuilder = (context) => Container();
+    OctoPlaceholderBuilder? octoPlaceholderBuilder;
+    OctoProgressIndicatorBuilder? octoProgressIndicatorBuilder;
+    Duration? effectiveFadeOutDuration = widget.fadeOutDuration;
+    Duration effectiveFadeInDuration = widget.fadeInDuration;
+    Duration? effectivePlaceholderFadeInDuration =
+        widget.placeholderFadeInDuration;
+
+    if (_skipPlaceholder) {
+      // Image is in disk cache — skip placeholder and fade animations
+      // so the image appears instantly.
+      octoPlaceholderBuilder = null;
+      octoProgressIndicatorBuilder = null;
+      effectiveFadeOutDuration = Duration.zero;
+      effectiveFadeInDuration = Duration.zero;
+      effectivePlaceholderFadeInDuration = Duration.zero;
+    } else {
+      octoPlaceholderBuilder =
+          widget.placeholder != null ? _octoPlaceholderBuilder : null;
+      octoProgressIndicatorBuilder = widget.progressIndicatorBuilder != null
+          ? _octoProgressIndicatorBuilder
+          : null;
+
+      /// If there is no placeholder OctoImage does not fade, so always set an
+      /// (empty) placeholder as this always used to be the behaviour of
+      /// CachedNetworkImage.
+      if (octoPlaceholderBuilder == null &&
+          octoProgressIndicatorBuilder == null) {
+        octoPlaceholderBuilder = (context) => Container();
+      }
     }
 
     return OctoImage(
       image: _image,
-      imageBuilder: imageBuilder != null ? _octoImageBuilder : null,
+      imageBuilder: widget.imageBuilder != null ? _octoImageBuilder : null,
       placeholderBuilder: octoPlaceholderBuilder,
       progressIndicatorBuilder: octoProgressIndicatorBuilder,
       errorBuilder: hasCustomBuilder ? _octoErrorBuilder : null,
-      fadeOutDuration: fadeOutDuration,
-      fadeOutCurve: fadeOutCurve,
-      fadeInDuration: fadeInDuration,
-      fadeInCurve: fadeInCurve,
-      width: width,
-      height: height,
-      fit: fit,
-      alignment: alignment,
-      repeat: repeat,
-      matchTextDirection: matchTextDirection,
-      color: color,
-      filterQuality: filterQuality,
-      colorBlendMode: colorBlendMode,
-      placeholderFadeInDuration: placeholderFadeInDuration,
-      gaplessPlayback: useOldImageOnUrlChange,
-      memCacheWidth: memCacheWidth,
-      memCacheHeight: memCacheHeight,
+      fadeOutDuration: effectiveFadeOutDuration,
+      fadeOutCurve: widget.fadeOutCurve,
+      fadeInDuration: effectiveFadeInDuration,
+      fadeInCurve: widget.fadeInCurve,
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit,
+      alignment: widget.alignment,
+      repeat: widget.repeat,
+      matchTextDirection: widget.matchTextDirection,
+      color: widget.color,
+      filterQuality: widget.filterQuality,
+      colorBlendMode: widget.colorBlendMode,
+      placeholderFadeInDuration: effectivePlaceholderFadeInDuration,
+      gaplessPlayback: widget.useOldImageOnUrlChange,
+      memCacheWidth: widget.memCacheWidth,
+      memCacheHeight: widget.memCacheHeight,
     );
   }
 
   Widget _octoImageBuilder(BuildContext context, Widget child) {
-    return imageBuilder!(context, _image);
+    return widget.imageBuilder!(context, _image);
   }
 
   Widget _octoPlaceholderBuilder(BuildContext context) {
-    return placeholder!(context, imageUrl);
+    return widget.placeholder!(context, widget.imageUrl);
   }
 
   Widget _octoProgressIndicatorBuilder(
@@ -359,10 +461,10 @@ class CachedNetworkImage extends StatelessWidget {
       totalSize = progress.expectedTotalBytes;
       downloaded = progress.cumulativeBytesLoaded;
     }
-    return progressIndicatorBuilder!(
+    return widget.progressIndicatorBuilder!(
       context,
-      imageUrl,
-      DownloadProgress(imageUrl, totalSize, downloaded),
+      widget.imageUrl,
+      DownloadProgress(widget.imageUrl, totalSize, downloaded),
     );
   }
 
@@ -372,14 +474,15 @@ class CachedNetworkImage extends StatelessWidget {
     StackTrace? stackTrace,
   ) {
     if (error is UnsupportedImageFormatException &&
-        unsupportedImageBuilder != null) {
-      return unsupportedImageBuilder!(context, imageUrl, error.bytes);
+        widget.unsupportedImageBuilder != null) {
+      return widget.unsupportedImageBuilder!(
+          context, widget.imageUrl, error.bytes);
     }
-    if (errorBuilder != null) {
-      return errorBuilder!(context, error, stackTrace);
+    if (widget.errorBuilder != null) {
+      return widget.errorBuilder!(context, error, stackTrace);
     }
-    if (errorWidget != null) {
-      return errorWidget!(context, imageUrl, error);
+    if (widget.errorWidget != null) {
+      return widget.errorWidget!(context, widget.imageUrl, error);
     }
     return const SizedBox.shrink();
   }

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.3.0
+version: 4.4.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/cached_image_widget_test.dart
+++ b/cached_network_image/test/cached_image_widget_test.dart
@@ -313,4 +313,142 @@ void main() {
       CachedNetworkImage.logLevel = originalLevel;
     });
   });
+
+  group('CachedNetworkImage placeholder skip on cache hit', () {
+    testWidgets('skips placeholder when image is in disk cache',
+        (tester) async {
+      var imageUrl = 'cached-image-test';
+      cacheManager.returnsFromCache(imageUrl, kTransparentImage);
+      cacheManager.returns(imageUrl, kTransparentImage);
+      var placeholderBuilt = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              placeholder: (context, url) {
+                placeholderBuilt = true;
+                return const CircularProgressIndicator();
+              },
+            ),
+          ),
+        ),
+      );
+      // Let the async cache check complete
+      await tester.pumpAndSettle();
+      expect(placeholderBuilt, isFalse,
+          reason: 'Placeholder should not be shown for cached images');
+    });
+
+    testWidgets('shows placeholder when image is NOT in disk cache',
+        (tester) async {
+      var imageUrl = 'not-cached-image-test';
+      cacheManager.returnsNotCached(imageUrl);
+      cacheManager.returns(imageUrl, kTransparentImage);
+      var placeholderBuilt = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              placeholder: (context, url) {
+                placeholderBuilt = true;
+                return const CircularProgressIndicator();
+              },
+            ),
+          ),
+        ),
+      );
+      // Let the async cache check complete and trigger setState
+      await tester.pump();
+      await tester.pump();
+      expect(placeholderBuilt, isTrue,
+          reason: 'Placeholder should be shown for non-cached images');
+    });
+
+    testWidgets('re-checks cache when imageUrl changes', (tester) async {
+      var cachedUrl = 'cached-url';
+      var uncachedUrl = 'uncached-url';
+      cacheManager.returnsFromCache(cachedUrl, kTransparentImage);
+      cacheManager.returns(cachedUrl, kTransparentImage);
+      cacheManager.returnsNotCached(uncachedUrl);
+      cacheManager.returns(uncachedUrl, kTransparentImage);
+
+      var placeholderBuilt = false;
+      var currentUrl = cachedUrl;
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    CachedNetworkImage(
+                      imageUrl: currentUrl,
+                      cacheManager: cacheManager,
+                      placeholder: (context, url) {
+                        placeholderBuilt = true;
+                        return const CircularProgressIndicator();
+                      },
+                    ),
+                    TextButton(
+                      onPressed: () =>
+                          setState(() => currentUrl = uncachedUrl),
+                      child: const Text('Switch'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(placeholderBuilt, isFalse,
+          reason: 'Placeholder should be skipped for cached URL');
+
+      // Switch to uncached URL
+      placeholderBuilt = false;
+      await tester.tap(find.text('Switch'));
+      await tester.pump();
+      await tester.pump();
+      expect(placeholderBuilt, isTrue,
+          reason:
+              'Placeholder should appear after switching to uncached URL');
+    });
+
+    testWidgets(
+        'always shows placeholder when disablePlaceholderOnCacheHit is false',
+        (tester) async {
+      var imageUrl = 'always-placeholder-test';
+      cacheManager.returnsFromCache(imageUrl, kTransparentImage);
+      cacheManager.returns(imageUrl, kTransparentImage);
+      var placeholderBuilt = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              disablePlaceholderOnCacheHit: false,
+              placeholder: (context, url) {
+                placeholderBuilt = true;
+                return const CircularProgressIndicator();
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(placeholderBuilt, isTrue,
+          reason:
+              'Placeholder should always show when disablePlaceholderOnCacheHit is false');
+    });
+  });
 }

--- a/cached_network_image/test/cached_image_widget_test.dart
+++ b/cached_network_image/test/cached_image_widget_test.dart
@@ -397,8 +397,7 @@ void main() {
                       },
                     ),
                     TextButton(
-                      onPressed: () =>
-                          setState(() => currentUrl = uncachedUrl),
+                      onPressed: () => setState(() => currentUrl = uncachedUrl),
                       child: const Text('Switch'),
                     ),
                   ],
@@ -418,8 +417,7 @@ void main() {
       await tester.pump();
       await tester.pump();
       expect(placeholderBuilt, isTrue,
-          reason:
-              'Placeholder should appear after switching to uncached URL');
+          reason: 'Placeholder should appear after switching to uncached URL');
     });
 
     testWidgets(

--- a/cached_network_image/test/fake_cache_manager.dart
+++ b/cached_network_image/test/fake_cache_manager.dart
@@ -27,6 +27,35 @@ class FakeCacheManager extends Mock implements CacheManager {
     );
   }
 
+  /// Stubs [getFileFromCache] to return a [FileInfo] with [FileSource.Cache],
+  /// simulating a disk-cache hit for the pre-check in
+  /// [CachedNetworkImage].
+  void returnsFromCache(String url, List<int> imageData) {
+    final file = MemoryFileSystem().systemTempDirectory.childFile('test.jpg');
+    file.writeAsBytesSync(imageData);
+    when(
+      () => getFileFromCache(
+        url,
+        ignoreMemCache: any(named: 'ignoreMemCache'),
+      ),
+    ).thenAnswer((_) async => FileInfo(
+          file,
+          FileSource.Cache,
+          DateTime.now().add(const Duration(days: 1)),
+          url,
+        ));
+  }
+
+  /// Stubs [getFileFromCache] to return `null`, simulating a cache miss.
+  void returnsNotCached(String url) {
+    when(
+      () => getFileFromCache(
+        url,
+        ignoreMemCache: any(named: 'ignoreMemCache'),
+      ),
+    ).thenAnswer((_) async => null);
+  }
+
   ExpectedData returns(
     String url,
     List<int> imageData, {


### PR DESCRIPTION
CachedNetworkImage now skips the placeholder and fade animations when images are loaded from disk cache, allowing them to appear instantly without visual flicker. The widget has been refactored to a StatefulWidget to manage state more effectively, with an added parameter `disablePlaceholderOnCacheHit` for backward compatibility. Tests have been included to verify the new behavior for cached and non-cached images.

## Description

### Problem

CachedNetworkImage
 always showed a placeholder widget and a 1.5s fade animation (1000ms fade-out + 500ms fade-in), even when images loaded from disk cache in ~50ms. This caused unnecessary visual flicker — a brief flash of placeholder followed by a slow crossfade for images that should appear instantly.

Root cause: OctoImage's frameBuilder uses Flutter's wasSynchronouslyLoaded flag. Since disk-cached images still load asynchronously (file I/O + decode = async), this flag is always false, triggering the full placeholder + fade flow even for fast cache hits.

### Approach
Converted CachedNetworkImage to a StatefulWidget that pre-checks the disk cache before the first meaningful frame:

In initState, call cacheManager.getFileFromCache() asynchronously
Optimistically assume cached (_skipPlaceholder = true) to avoid even a single-frame placeholder flash
If the check reveals the image is NOT cached, setState flips to showing the placeholder normally
Added disablePlaceholderOnCacheHit parameter (default true) for backward-compatible opt-out

## Related Issues

Relates to https://github.com/Baseflow/flutter_cached_network_image/issues/164

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk-cached images now display instantly on cache hit, skipping placeholder and fade animations by default.
  * Added new configuration options: disablePlaceholderOnCacheHit (toggle), imageRenderMethodForWeb, and scale.

* **Tests**
  * Added tests covering placeholder behavior for cache hits, misses, config changes, and the new toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->