### PR TITLE
Add persistent web caching via Hive CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We benchmarked the cache metadata operations (checking, writing, and deleting ca
 * **Drop-in Replacement:** 99% API compatible with the original package.
 * **High Performance:** Powered by `hive_ce` for instant cache lookups.
 * **Actively Maintained:** Regular updates, bug fixes, and community-driven roadmap.
-* **Web Support:** Minimal support for web (currently works like standard `Image.network`).
+* **True Web Support:** Unlike the original package, CE provides **full, persistent image caching** on the Web via IndexedDB (`hive_ce`), completely avoiding RAM freezes by using native image decoding sizes.
 
 ## 📦 Installation
 
@@ -128,9 +128,13 @@ A: Yes. Because we switched the storage engine from SQLite to Hive, the old cach
 **Q: My app crashes/pauses on errors?**
 A: In Debug mode, Flutter may pause on exceptions even if they are caught. This is expected behavior for network errors (404s). In Release mode, these are handled silently by the `errorWidget`.
 
+**Q: Why is web caching slower or using Hive for image bytes?**
+A: On Mobile & Desktop (IO), this package stores image bytes directly on the incredibly fast native file system, and uses Hive *only* for metadata. The Web platform, however, lacks a native file system. Therefore, for web we use `hive_ce` to store both metadata and the actual image bytes in IndexedDB. Serializing large byte arrays in and out of IndexedDB introduces overhead that isn't present on IO. 
+*Alternative:* If persistent caching across sessions isn't critical for your web users, consider conditionally using the standard `Image.network` on the web, which relies on the browser's built-in memory/HTTP caching to achieve faster decoding.
+
 ## 🤝 Contributing
 
-We welcome contributions! If you want to help maintain this essential package, please check the [CONTRIBUTING.md](https://www.google.com/search?q=CONTRIBUTING.md).
+We welcome contributions! If you want to help maintain this essential package, please check the [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 📄 License
 

--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.5.0] - 2026-03-02
+
+* **Feature:** Added web platform support. The package can now be used in Flutter web apps.
+  * Web caching uses Hive CE backed by IndexedDB — no new dependencies needed.
+  * Image bytes and metadata are stored in Hive boxes on web instead of the file system.
+  * Disk-based image resizing is skipped on web (originals are cached as-is).
+  * The `DefaultCacheManager` is now conditionally imported per platform (IO/web).
+
 ## [4.4.0] - 2026-02-27
 
 * **Feature:** Skip placeholder and fade animations when images are loaded from disk cache. Cached images now appear instantly without unnecessary visual flicker.

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -52,11 +52,10 @@ We benchmarked the cache metadata operations (checking, writing, and deleting ca
 
 ## 📦 Installation
 
-Add `cached_network_image_ce` to your `pubspec.yaml`:
+Run the following command:
 
-```yaml
-dependencies:
-  cached_network_image_ce: ^4.0.1
+```sh
+flutter pub add cached_network_image_ce
 ```
 
 ## 💻 How to use

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -48,7 +48,7 @@ We benchmarked the cache metadata operations (checking, writing, and deleting ca
 * **Drop-in Replacement:** 99% API compatible with the original package.
 * **High Performance:** Powered by `hive_ce` for instant cache lookups.
 * **Actively Maintained:** Regular updates, bug fixes, and community-driven roadmap.
-* **Web Support:** Minimal support for web (currently works like standard `Image.network`).
+* **True Web Support:** Unlike the original package, CE provides **full, persistent image caching** on the Web via IndexedDB (`hive_ce`), completely avoiding RAM freezes by using native image decoding sizes.
 
 ## 📦 Installation
 
@@ -61,8 +61,7 @@ dependencies:
 
 ## 💻 How to use
 
-The API is identical to the original package. You can use `CachedNetworkImage` directly or via `ImageProvider`.
-Both `CachedNetworkImage` and `CachedNetworkImageProvider` have minimal support for web (currently without caching).
+The API is identical to the original package. You can use `CachedNetworkImage` directly or via `ImageProvider`. Both approaches are fully supported with persistent IndexedDB caching on the web platform out-of-the-box.
 
 ### Basic Usage with Placeholder
 
@@ -148,6 +147,10 @@ A: Yes. Because we switched the storage engine from SQLite to Hive, the old cach
 
 **Q: My app crashes/pauses on errors?**
 A: In Debug mode, Flutter may pause on exceptions even if they are caught. This is expected behavior for network errors (404s). In Release mode, these are handled silently by the `errorWidget`.
+
+**Q: Why is web caching slower or using Hive for image bytes?**
+A: On Mobile & Desktop (IO), this package stores image bytes directly on the incredibly fast native file system, and uses Hive *only* for metadata. The Web platform, however, lacks a native file system. Therefore, for web we use `hive_ce` to store both metadata and the actual image bytes in IndexedDB. Serializing large byte arrays in and out of IndexedDB introduces overhead that isn't present on IO. 
+*Alternative:* If persistent caching across sessions isn't critical for your web users, consider conditionally using the standard `Image.network` on the web, which relies on the browser's built-in memory/HTTP caching to achieve faster decoding.
 
 ## 🤝 Contributing
 

--- a/cached_network_image/devtools_options.yaml
+++ b/cached_network_image/devtools_options.yaml
@@ -1,3 +1,4 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
-extensions: []
+extensions:
+  - hive_ce: true

--- a/cached_network_image/example/devtools_options.yaml
+++ b/cached_network_image/example/devtools_options.yaml
@@ -1,3 +1,4 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
-extensions: []
+extensions:
+  - hive_ce: true

--- a/cached_network_image/lib/cached_network_image.dart
+++ b/cached_network_image/lib/cached_network_image.dart
@@ -16,7 +16,7 @@ export 'package:cached_network_image_platform_interface_ce/cached_network_image_
         ImageFormatDetector,
         UnsupportedImageFormatException;
 
-export 'src/cache/default_cache_manager.dart';
+export 'src/cache/default_cache_manager_factory.dart';
 export 'src/cached_image_widget.dart';
 export 'src/image_provider/cached_network_image_provider.dart';
 export 'src/image_provider/multi_image_stream_completer.dart';

--- a/cached_network_image/lib/src/cache/cache_entry_metadata.dart
+++ b/cached_network_image/lib/src/cache/cache_entry_metadata.dart
@@ -1,0 +1,47 @@
+/// Typed metadata for a cached file entry, stored in Hive.
+class CacheEntryMetadata {
+  CacheEntryMetadata({
+    required this.url,
+    required this.relativePath,
+    required this.validTill,
+    this.eTag,
+    this.length = 0,
+  });
+
+  /// Reconstructs a [CacheEntryMetadata] from a Hive-stored [Map].
+  factory CacheEntryMetadata.fromMap(Map map) {
+    return CacheEntryMetadata(
+      url: map['url'] as String,
+      relativePath: map['relativePath'] as String,
+      validTill: DateTime.fromMillisecondsSinceEpoch(map['validTill'] as int),
+      eTag: map['eTag'] as String?,
+      length: (map['length'] as int?) ?? 0,
+    );
+  }
+
+  /// The original download URL.
+  final String url;
+
+  /// The path of the cached file relative to the cache directory.
+  final String relativePath;
+
+  /// When this cache entry expires.
+  final DateTime validTill;
+
+  /// The HTTP ETag for revalidation, if any.
+  final String? eTag;
+
+  /// The size of the cached file in bytes.
+  final int length;
+
+  /// Serializes this metadata to a [Map] for Hive storage.
+  Map<String, dynamic> toMap() {
+    return {
+      'url': url,
+      'relativePath': relativePath,
+      'validTill': validTill.millisecondsSinceEpoch,
+      'eTag': eTag,
+      'length': length,
+    };
+  }
+}

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -14,6 +14,10 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
+import 'cache_entry_metadata.dart';
+
+export 'cache_entry_metadata.dart';
+
 const _kBoxName = 'cached_network_image_cache';
 const _kDefaultMaxAge = Duration(days: 30);
 const _kDefaultMaxCacheObjects = 200;
@@ -21,53 +25,7 @@ const _kDefaultStalePeriod = Duration(days: 7);
 
 const _supportedFileNames = ['jpg', 'jpeg', 'png', 'tga', 'cur', 'ico'];
 
-/// Typed metadata for a cached file entry, stored in Hive.
-class CacheEntryMetadata {
-  CacheEntryMetadata({
-    required this.url,
-    required this.relativePath,
-    required this.validTill,
-    this.eTag,
-    this.length = 0,
-  });
 
-  /// Reconstructs a [CacheEntryMetadata] from a Hive-stored [Map].
-  factory CacheEntryMetadata.fromMap(Map map) {
-    return CacheEntryMetadata(
-      url: map['url'] as String,
-      relativePath: map['relativePath'] as String,
-      validTill: DateTime.fromMillisecondsSinceEpoch(map['validTill'] as int),
-      eTag: map['eTag'] as String?,
-      length: (map['length'] as int?) ?? 0,
-    );
-  }
-
-  /// The original download URL.
-  final String url;
-
-  /// The path of the cached file relative to the cache directory.
-  final String relativePath;
-
-  /// When this cache entry expires.
-  final DateTime validTill;
-
-  /// The HTTP ETag for revalidation, if any.
-  final String? eTag;
-
-  /// The size of the cached file in bytes.
-  final int length;
-
-  /// Serializes this metadata to a [Map] for Hive storage.
-  Map<String, dynamic> toMap() {
-    return {
-      'url': url,
-      'relativePath': relativePath,
-      'validTill': validTill.millisecondsSinceEpoch,
-      'eTag': eTag,
-      'length': length,
-    };
-  }
-}
 
 /// Signature for a function that returns the cache base directory.
 ///

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -25,8 +25,6 @@ const _kDefaultStalePeriod = Duration(days: 7);
 
 const _supportedFileNames = ['jpg', 'jpeg', 'png', 'tga', 'cur', 'ico'];
 
-
-
 /// Signature for a function that returns the cache base directory.
 ///
 /// Defaults to [getTemporaryDirectory] when not specified.

--- a/cached_network_image/lib/src/cache/default_cache_manager_factory.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_factory.dart
@@ -1,0 +1,3 @@
+export 'default_cache_manager_stub.dart'
+    if (dart.library.io) 'default_cache_manager.dart'
+    if (dart.library.js_interop) 'default_cache_manager_web.dart';

--- a/cached_network_image/lib/src/cache/default_cache_manager_stub.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_stub.dart
@@ -1,0 +1,65 @@
+import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
+import 'package:file/file.dart';
+
+export 'cache_entry_metadata.dart';
+
+/// Stub [DefaultCacheManager] for unsupported platforms.
+///
+/// This is used as the fallback in the conditional import and should
+/// never actually be instantiated at runtime.
+class DefaultCacheManager extends CacheManager with ImageCacheManager {
+  DefaultCacheManager({
+    Duration stalePeriod = const Duration(days: 7),
+    int maxNrOfCacheObjects = 200,
+  }) {
+    throw UnsupportedError(
+      'DefaultCacheManager is not supported on this platform.',
+    );
+  }
+
+  @override
+  Future<void> dispose() => throw UnsupportedError('Unsupported platform');
+
+  @override
+  Future<void> emptyCache() => throw UnsupportedError('Unsupported platform');
+
+  @override
+  Future<FileInfo?> getFileFromCache(String key,
+          {bool ignoreMemCache = false}) =>
+      throw UnsupportedError('Unsupported platform');
+
+  @override
+  Stream<FileResponse> getFileStream(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+  }) =>
+      throw UnsupportedError('Unsupported platform');
+
+  @override
+  Stream<FileResponse> getImageFile(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+    int? maxHeight,
+    int? maxWidth,
+  }) =>
+      throw UnsupportedError('Unsupported platform');
+
+  @override
+  Future<File> putFile(
+    String url,
+    List<int> fileBytes, {
+    String? key,
+    String? eTag,
+    Duration maxAge = const Duration(days: 30),
+    String fileExtension = 'file',
+  }) =>
+      throw UnsupportedError('Unsupported platform');
+
+  @override
+  Future<void> removeFile(String key) =>
+      throw UnsupportedError('Unsupported platform');
+}

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -323,6 +323,21 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   @override
   Future<void> removeFile(String key) async {
     await _ensureInitialized();
+    final raw = _metaBox!.get(key);
+    if (raw != null) {
+      final metadata = CacheEntryMetadata.fromMap(raw);
+      try {
+        final file = _memFs.file('/${metadata.relativePath}');
+        if (file.existsSync()) {
+          await file.delete();
+        }
+      } on Object catch (e) {
+        cacheLogger.log(
+          'CacheManager: Error deleting materialized file for $key: $e',
+          CacheManagerLogLevel.warning,
+        );
+      }
+    }
     await _metaBox!.delete(key);
     await _dataBox!.delete(key);
   }
@@ -330,6 +345,20 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   @override
   Future<void> emptyCache() async {
     await _ensureInitialized();
+    for (final raw in _metaBox!.values) {
+      final metadata = CacheEntryMetadata.fromMap(raw);
+      try {
+        final file = _memFs.file('/${metadata.relativePath}');
+        if (file.existsSync()) {
+          await file.delete();
+        }
+      } on Object catch (e) {
+        cacheLogger.log(
+          'CacheManager: Error deleting materialized file during emptyCache: $e',
+          CacheManagerLogLevel.warning,
+        );
+      }
+        }
     await _metaBox!.clear();
     await _dataBox!.clear();
   }
@@ -455,8 +484,11 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       ).asBroadcastStream();
       _runningResizes[resizedKey] = runningResize;
     }
-    yield* runningResize;
-    _runningResizes.remove(resizedKey);
+    try {
+      yield* runningResize;
+    } finally {
+      _runningResizes.remove(resizedKey);
+    }
   }
 
   Stream<FileResponse> _fetchAndStoreAsResized(

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -138,7 +138,15 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     Map<String, String>? headers,
     bool withProgress,
   ) async {
-    await _ensureInitialized();
+    try {
+      await _ensureInitialized();
+    } on Object catch (e, stackTrace) {
+      if (controller.hasListener) {
+        controller.addError(e, stackTrace);
+      }
+      await controller.close();
+      return;
+    }
 
     FileInfo? cachedFile;
     try {

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -1,0 +1,488 @@
+import 'dart:async';
+
+import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:hive_ce/hive.dart';
+// ignore: implementation_imports
+import 'package:hive_ce/src/hive_impl.dart';
+import 'package:http/http.dart' as http;
+
+import 'cache_entry_metadata.dart';
+
+export 'cache_entry_metadata.dart';
+
+const _kMetaBoxName = 'cached_network_image_cache';
+const _kDataBoxName = 'cached_network_image_data';
+const _kDefaultMaxAge = Duration(days: 30);
+const _kDefaultMaxCacheObjects = 200;
+const _kDefaultStalePeriod = Duration(days: 7);
+
+/// Web-specific [DefaultCacheManager] that stores both metadata and raw
+/// image bytes in Hive boxes (backed by IndexedDB on web).
+///
+/// Because there is no real file system on the web, cached "files" are
+/// materialised as in-memory [File] objects using [MemoryFileSystem].
+class DefaultCacheManager extends CacheManager with ImageCacheManager {
+  /// Creates a [DefaultCacheManager] for the web platform.
+  ///
+  /// [stalePeriod] controls how long a cached entry remains valid.
+  /// [maxNrOfCacheObjects] caps the number of entries before cleanup.
+  /// [httpClientFactory] allows injecting a custom HTTP client for testing.
+  /// [hiveInstance] allows injecting a pre-initialised Hive instance
+  /// (useful for VM tests that need `Hive.init(path)` called first).
+  DefaultCacheManager({
+    this.stalePeriod = _kDefaultStalePeriod,
+    this.maxNrOfCacheObjects = _kDefaultMaxCacheObjects,
+    http.Client Function()? httpClientFactory,
+    @visibleForTesting HiveInterface? hiveInstance,
+  })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
+        _hive = hiveInstance ?? HiveImpl();
+
+  /// Duration before cached files are considered stale.
+  final Duration stalePeriod;
+
+  /// Maximum number of objects in the cache before cleanup.
+  final int maxNrOfCacheObjects;
+
+  /// Factory for creating HTTP clients.
+  final http.Client Function() _httpClientFactory;
+
+  /// In-memory file system used to materialise cached bytes as [File] objects.
+  final MemoryFileSystem _memFs = MemoryFileSystem();
+
+  /// Private Hive instance to avoid conflicts with the host app's Hive usage.
+  final HiveInterface _hive;
+
+  Box<Map>? _metaBox;
+  LazyBox<List<int>>? _dataBox;
+
+  /// Guards [_doInit] so concurrent callers share one init future.
+  Completer<void>? _initCompleter;
+
+  Future<void> _ensureInitialized() {
+    final currentCompleter = _initCompleter;
+    if (currentCompleter != null) return currentCompleter.future;
+
+    final completer = Completer<void>();
+    _initCompleter = completer;
+
+    _doInit().then((_) {
+      if (!completer.isCompleted) completer.complete();
+    }).catchError((Object e, StackTrace s) {
+      if (identical(_initCompleter, completer)) _initCompleter = null;
+      if (!completer.isCompleted) completer.completeError(e, s);
+    });
+
+    return completer.future;
+  }
+
+  Future<void> _doInit() async {
+    // On web, Hive uses IndexedDB — no path argument needed.
+    // We use a private HiveImpl instance to avoid conflicts with the
+    // host app's own Hive boxes.
+    _metaBox = await _hive.openBox<Map>(_kMetaBoxName);
+    _dataBox = await _hive.openLazyBox<List<int>>(_kDataBoxName);
+
+    // Run cleanup in background.
+    unawaited(_cleanupOldEntries());
+  }
+
+  /// Gets the file extension from a URL.
+  String _getFileExtensionFromUrl(String url) {
+    try {
+      final uri = Uri.parse(url);
+      final pathSegment =
+          uri.pathSegments.isNotEmpty ? uri.pathSegments.last : '';
+      if (pathSegment.contains('.')) {
+        return pathSegment.split('.').last.toLowerCase();
+      }
+    } on Object catch (_) {
+      // Ignore parse errors
+    }
+    return 'file';
+  }
+
+  /// Materialises raw [bytes] as an in-memory [File].
+  File _bytesToFile(String key, List<int> bytes) {
+    final ext = _getFileExtensionFromUrl(key);
+    // Use a hash of the key for the filename to avoid invalid path characters
+    // (URLs contain colons and slashes that MemoryFileSystem interprets as dirs).
+    final hashedName = key.hashCode.toUnsigned(32).toRadixString(16);
+    final file = _memFs.file('/$hashedName.$ext');
+    file.writeAsBytesSync(bytes);
+    return file;
+  }
+
+  // ---------------------------------------------------------------
+  // BaseCacheManager
+  // ---------------------------------------------------------------
+
+  @override
+  Stream<FileResponse> getFileStream(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+  }) {
+    final controller = StreamController<FileResponse>();
+    _pushFileToStream(controller, url, key ?? url, headers, withProgress);
+    return controller.stream;
+  }
+
+  Future<void> _pushFileToStream(
+    StreamController<FileResponse> controller,
+    String url,
+    String key,
+    Map<String, String>? headers,
+    bool withProgress,
+  ) async {
+    await _ensureInitialized();
+
+    FileInfo? cachedFile;
+    try {
+      cachedFile = await getFileFromCache(key);
+      if (cachedFile != null) {
+        controller.add(cachedFile);
+        withProgress = false;
+      }
+    } on Object catch (e) {
+      cacheLogger.log(
+        'CacheManager: Failed to load cached file for $url with error:\n$e',
+        CacheManagerLogLevel.debug,
+      );
+    }
+
+    if (cachedFile == null || cachedFile.validTill.isBefore(DateTime.now())) {
+      try {
+        await for (final response
+            in _downloadFile(url, key, headers, withProgress)) {
+          if (response is DownloadProgress && withProgress) {
+            controller.add(response);
+          }
+          if (response is FileInfo) {
+            controller.add(response);
+          }
+        }
+      } on Object catch (e) {
+        cacheLogger.log(
+          'CacheManager: Failed to download file from $url with error:\n$e',
+          CacheManagerLogLevel.debug,
+        );
+        if (cachedFile == null && controller.hasListener) {
+          controller.addError(e);
+        }
+        if (cachedFile != null &&
+            e is HttpExceptionWithStatus &&
+            e.statusCode == 404) {
+          if (controller.hasListener) {
+            controller.addError(e);
+          }
+          await removeFile(key);
+        }
+      }
+    }
+    await controller.close();
+  }
+
+  Stream<FileResponse> _downloadFile(
+    String url,
+    String key,
+    Map<String, String>? headers,
+    bool withProgress,
+  ) async* {
+    cacheLogger.log(
+      'CacheManager: Downloading $url',
+      CacheManagerLogLevel.verbose,
+    );
+
+    final request = http.Request('GET', Uri.parse(url));
+    if (headers != null) {
+      request.headers.addAll(headers);
+    }
+
+    final client = _httpClientFactory();
+    try {
+      final response = await client.send(request);
+
+      if (response.statusCode != 200 && response.statusCode != 202) {
+        throw HttpExceptionWithStatus(
+          response.statusCode,
+          'Invalid statusCode: ${response.statusCode}',
+          uri: Uri.parse(url),
+        );
+      }
+
+      final contentLength = response.contentLength;
+      final allBytes = <int>[];
+      var receivedBytes = 0;
+
+      await for (final chunk in response.stream) {
+        receivedBytes += chunk.length;
+        allBytes.addAll(chunk);
+        if (withProgress) {
+          yield DownloadProgress(url, contentLength, receivedBytes);
+        }
+      }
+
+      // Store metadata + data in Hive.
+      final validTill = DateTime.now().add(stalePeriod);
+      final cacheHeaders = response.headers;
+      final eTag = cacheHeaders['etag'];
+      final fileExtension = _getFileExtensionFromUrl(url);
+      final relativePath =
+          '${key.hashCode.toUnsigned(32).toRadixString(16)}.$fileExtension';
+
+      await _metaBox!.put(
+        key,
+        CacheEntryMetadata(
+          url: url,
+          relativePath: relativePath,
+          validTill: validTill,
+          eTag: eTag,
+          length: receivedBytes,
+        ).toMap(),
+      );
+      await _dataBox!.put(key, allBytes);
+
+      final file = _bytesToFile(key, allBytes);
+      yield FileInfo(file, FileSource.Online, validTill, url);
+    } finally {
+      client.close();
+    }
+  }
+
+  @override
+  Future<FileInfo?> getFileFromCache(
+    String key, {
+    bool ignoreMemCache = false,
+  }) async {
+    await _ensureInitialized();
+
+    final raw = _metaBox!.get(key);
+    if (raw == null) return null;
+
+    final metadata = CacheEntryMetadata.fromMap(raw);
+
+    final bytes = await _dataBox!.get(key);
+    if (bytes == null) {
+      // Metadata exists but data is missing — clean up.
+      await _metaBox!.delete(key);
+      return null;
+    }
+
+    final file = _bytesToFile(key, bytes);
+    return FileInfo(
+      file,
+      FileSource.Cache,
+      metadata.validTill,
+      metadata.url,
+    );
+  }
+
+  @override
+  Future<File> putFile(
+    String url,
+    List<int> fileBytes, {
+    String? key,
+    String? eTag,
+    Duration maxAge = _kDefaultMaxAge,
+    String fileExtension = 'file',
+  }) async {
+    await _ensureInitialized();
+
+    key ??= url;
+    final relativePath =
+        '${key.hashCode.toUnsigned(32).toRadixString(16)}.$fileExtension';
+    final validTill = DateTime.now().add(maxAge);
+
+    await _metaBox!.put(
+      key,
+      CacheEntryMetadata(
+        url: url,
+        relativePath: relativePath,
+        validTill: validTill,
+        eTag: eTag,
+        length: fileBytes.length,
+      ).toMap(),
+    );
+    await _dataBox!.put(key, fileBytes);
+
+    return _bytesToFile(key, fileBytes);
+  }
+
+  @override
+  Future<void> removeFile(String key) async {
+    await _ensureInitialized();
+    await _metaBox!.delete(key);
+    await _dataBox!.delete(key);
+  }
+
+  @override
+  Future<void> emptyCache() async {
+    await _ensureInitialized();
+    await _metaBox!.clear();
+    await _dataBox!.clear();
+  }
+
+  @override
+  Future<void> dispose() async {
+    final inFlightInit = _initCompleter;
+    if (inFlightInit != null) {
+      try {
+        await inFlightInit.future;
+      } on Object catch (_) {
+        // Ignore init errors during dispose.
+      }
+    }
+
+    if (_metaBox != null && _metaBox!.isOpen) {
+      await _metaBox!.close();
+    }
+    if (_dataBox != null && _dataBox!.isOpen) {
+      await _dataBox!.close();
+    }
+
+    _metaBox = null;
+    _dataBox = null;
+    _initCompleter = null;
+  }
+
+  /// Clean up entries that have expired.
+  Future<void> _cleanupOldEntries() async {
+    try {
+      final now = DateTime.now();
+      final entries = <MapEntry<dynamic, CacheEntryMetadata>>[];
+
+      for (final key in _metaBox!.keys.toList()) {
+        final raw = _metaBox!.get(key);
+        if (raw != null) {
+          entries.add(MapEntry(key, CacheEntryMetadata.fromMap(raw)));
+        }
+      }
+
+      // Remove expired entries.
+      for (final entry in entries) {
+        if (entry.value.validTill.isBefore(now)) {
+          await _metaBox!.delete(entry.key);
+          await _dataBox!.delete(entry.key);
+        }
+      }
+
+      // If cache is still too large, remove oldest entries.
+      if (_metaBox!.length > maxNrOfCacheObjects) {
+        final sortedEntries = entries
+            .where((e) => _metaBox!.containsKey(e.key))
+            .toList()
+          ..sort((a, b) => a.value.validTill.compareTo(b.value.validTill));
+
+        final toRemove = sortedEntries.length - maxNrOfCacheObjects;
+        for (var i = 0; i < toRemove; i++) {
+          final entry = sortedEntries[i];
+          await _metaBox!.delete(entry.key);
+          await _dataBox!.delete(entry.key);
+        }
+      }
+    } on Object catch (e) {
+      cacheLogger.log(
+        'CacheManager: Error during cleanup: $e',
+        CacheManagerLogLevel.warning,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // ImageCacheManager
+  // ---------------------------------------------------------------
+
+  final Map<String, Stream<FileResponse>> _runningResizes = {};
+
+  @override
+  Stream<FileResponse> getImageFile(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+    int? maxHeight,
+    int? maxWidth,
+  }) async* {
+    // On web, we don't support disk-based image resizing.
+    // Just forward to getFileStream.
+    if (maxHeight == null && maxWidth == null) {
+      yield* getFileStream(
+        url,
+        key: key,
+        headers: headers,
+        withProgress: withProgress,
+      );
+      return;
+    }
+
+    key ??= url;
+    var resizedKey = 'resized';
+    if (maxWidth != null) resizedKey += '_w$maxWidth';
+    if (maxHeight != null) resizedKey += '_h$maxHeight';
+    resizedKey += '_$key';
+
+    final fromCache = await getFileFromCache(resizedKey);
+    if (fromCache != null) {
+      yield fromCache;
+      if (fromCache.validTill.isAfter(DateTime.now())) {
+        return;
+      }
+      withProgress = false;
+    }
+
+    // On web we can't resize images on disk, so we store the original
+    // under the resized key so that the cache-key system still works.
+    var runningResize = _runningResizes[resizedKey];
+    if (runningResize == null) {
+      runningResize = _fetchAndStoreAsResized(
+        url,
+        key,
+        resizedKey,
+        headers,
+        withProgress,
+      ).asBroadcastStream();
+      _runningResizes[resizedKey] = runningResize;
+    }
+    yield* runningResize;
+    _runningResizes.remove(resizedKey);
+  }
+
+  Stream<FileResponse> _fetchAndStoreAsResized(
+    String url,
+    String originalKey,
+    String resizedKey,
+    Map<String, String>? headers,
+    bool withProgress,
+  ) async* {
+    await for (final response in getFileStream(
+      url,
+      key: originalKey,
+      headers: headers,
+      withProgress: withProgress,
+    )) {
+      if (response is DownloadProgress) {
+        yield response;
+      }
+      if (response is FileInfo) {
+        // Store the original bytes under the resized key.
+        final bytes = await response.file.readAsBytes();
+        final file = await putFile(
+          url,
+          bytes,
+          key: resizedKey,
+          maxAge: response.validTill.difference(DateTime.now()),
+        );
+        yield FileInfo(
+          file,
+          response.source,
+          response.validTill,
+          response.originalUrl,
+        );
+      }
+    }
+  }
+}

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -358,7 +358,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
           CacheManagerLogLevel.warning,
         );
       }
-        }
+    }
     await _metaBox!.clear();
     await _dataBox!.clear();
   }

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -105,12 +105,8 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   }
 
   /// Materialises raw [bytes] as an in-memory [File].
-  File _bytesToFile(String key, List<int> bytes) {
-    final ext = _getFileExtensionFromUrl(key);
-    // Use a hash of the key for the filename to avoid invalid path characters
-    // (URLs contain colons and slashes that MemoryFileSystem interprets as dirs).
-    final hashedName = key.hashCode.toUnsigned(32).toRadixString(16);
-    final file = _memFs.file('/$hashedName.$ext');
+  File _bytesToFile(String relativePath, List<int> bytes) {
+    final file = _memFs.file('/$relativePath');
     file.writeAsBytesSync(bytes);
     return file;
   }
@@ -254,7 +250,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       );
       await _dataBox!.put(key, allBytes);
 
-      final file = _bytesToFile(key, allBytes);
+      final file = _bytesToFile(relativePath, allBytes);
       yield FileInfo(file, FileSource.Online, validTill, url);
     } finally {
       client.close();
@@ -280,7 +276,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       return null;
     }
 
-    final file = _bytesToFile(key, bytes);
+    final file = _bytesToFile(metadata.relativePath, bytes);
     return FileInfo(
       file,
       FileSource.Cache,
@@ -317,7 +313,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     );
     await _dataBox!.put(key, fileBytes);
 
-    return _bytesToFile(key, fileBytes);
+    return _bytesToFile(relativePath, fileBytes);
   }
 
   @override
@@ -404,6 +400,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         if (entry.value.validTill.isBefore(now)) {
           await _metaBox!.delete(entry.key);
           await _dataBox!.delete(entry.key);
+          try {
+            final file = _memFs.file('/${entry.value.relativePath}');
+            if (file.existsSync()) {
+              await file.delete();
+            }
+          } on Object catch (_) {}
         }
       }
 
@@ -419,6 +421,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
           final entry = sortedEntries[i];
           await _metaBox!.delete(entry.key);
           await _dataBox!.delete(entry.key);
+          try {
+            final file = _memFs.file('/${entry.value.relativePath}');
+            if (file.existsSync()) {
+              await file.delete();
+            }
+          } on Object catch (_) {}
         }
       }
     } on Object catch (e) {
@@ -487,7 +495,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     try {
       yield* runningResize;
     } finally {
-      _runningResizes.remove(resizedKey);
+      if (_runningResizes[resizedKey] == runningResize) {
+        _runningResizes.remove(resizedKey);
+      }
     }
   }
 

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.4.0
+version: 4.5.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -743,7 +743,8 @@ void main() {
         }
       }
 
-      expect(cleanupSuccess, isTrue, reason: 'Background cleanup failed or timed out');
+      expect(cleanupSuccess, isTrue,
+          reason: 'Background cleanup failed or timed out');
 
       // At minimum, the newest entries should be available
       final newest = await manager2.getFileFromCache(

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -420,7 +420,7 @@ void main() {
 
       // Should have two FileInfo events: one from cache, one from download
       final fileInfos = events2.whereType<FileInfo>().toList();
-      expect(fileInfos.length, greaterThanOrEqualTo(1));
+      expect(fileInfos.length, equals(2));
 
       await manager.emptyCache();
       await manager.dispose();

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -353,12 +353,10 @@ void main() {
         ),
       );
 
-      await manager
-          .getFileStream(
-            'https://example.com/headers.png',
-            headers: {'Authorization': 'Bearer token123'},
-          )
-          .toList();
+      await manager.getFileStream(
+        'https://example.com/headers.png',
+        headers: {'Authorization': 'Bearer token123'},
+      ).toList();
 
       expect(receivedHeaders, isNotNull);
       expect(receivedHeaders!['Authorization'], 'Bearer token123');
@@ -409,18 +407,15 @@ void main() {
       );
 
       // First request — download
-      await manager
-          .getFileStream('https://example.com/stale.png')
-          .toList();
+      await manager.getFileStream('https://example.com/stale.png').toList();
       expect(downloadCount, 1);
 
       // Wait a tiny bit to ensure stalePeriod (zero) has passed
       await Future<void>.delayed(const Duration(milliseconds: 10));
 
       // Second request — should serve stale cache AND redownload
-      final events2 = await manager
-          .getFileStream('https://example.com/stale.png')
-          .toList();
+      final events2 =
+          await manager.getFileStream('https://example.com/stale.png').toList();
       expect(downloadCount, 2);
 
       // Should have two FileInfo events: one from cache, one from download
@@ -445,9 +440,8 @@ void main() {
         ),
       );
 
-      final events = await manager
-          .getImageFile('https://example.com/image.png')
-          .toList();
+      final events =
+          await manager.getImageFile('https://example.com/image.png').toList();
 
       final fileInfos = events.whereType<FileInfo>().toList();
       expect(fileInfos, hasLength(1));
@@ -732,7 +726,8 @@ void main() {
 
       // Trigger cleanup by disposing and re-creating
       await manager.dispose();
-      final manager2 = DefaultCacheManager(hiveInstance: testHive, maxNrOfCacheObjects: 3);
+      final manager2 =
+          DefaultCacheManager(hiveInstance: testHive, maxNrOfCacheObjects: 3);
 
       // The newest 3 entries should survive, oldest 2 may be cleaned up
       // (cleanup runs in background on init, we need to wait a moment)
@@ -748,8 +743,6 @@ void main() {
       await manager2.dispose();
     });
   });
-
-
 
   // =====================================================================
   // StreamController / http.Client lifecycle (leak checks)

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -1,0 +1,867 @@
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'package:cached_network_image_ce/src/cache/default_cache_manager_web.dart';
+import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+// ignore: implementation_imports
+import 'package:hive_ce/src/hive_impl.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart' as http_testing;
+
+void main() {
+  late io.Directory hiveTempDir;
+  late HiveInterface testHive;
+
+  setUp(() {
+    hiveTempDir =
+        io.Directory.systemTemp.createTempSync('web_cache_manager_test_');
+    testHive = HiveImpl();
+    testHive.init(hiveTempDir.path);
+  });
+
+  tearDown(() async {
+    await testHive.close();
+    try {
+      hiveTempDir.deleteSync(recursive: true);
+    } on Object catch (_) {}
+  });
+
+  // =====================================================================
+  // Constructor
+  // =====================================================================
+
+  group('WebCacheManager constructor', () {
+    test('uses default values', () {
+      final manager = DefaultCacheManager(hiveInstance: testHive);
+      expect(manager.stalePeriod, const Duration(days: 7));
+      expect(manager.maxNrOfCacheObjects, 200);
+    });
+
+    test('accepts custom values', () {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        stalePeriod: const Duration(days: 14),
+        maxNrOfCacheObjects: 50,
+      );
+      expect(manager.stalePeriod, const Duration(days: 14));
+      expect(manager.maxNrOfCacheObjects, 50);
+    });
+
+    test('accepts custom httpClientFactory', () {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('', 200),
+        ),
+      );
+      expect(manager, isA<DefaultCacheManager>());
+    });
+  });
+
+  // =====================================================================
+  // putFile / getFileFromCache / removeFile / emptyCache
+  // =====================================================================
+
+  group('WebCacheManager cache operations', () {
+    late DefaultCacheManager manager;
+
+    setUp(() {
+      manager = DefaultCacheManager(hiveInstance: testHive);
+    });
+
+    tearDown(() async {
+      try {
+        await manager.emptyCache();
+        await manager.dispose();
+      } on Object catch (_) {}
+    });
+
+    test('putFile stores data and getFileFromCache retrieves it', () async {
+      final bytes = [1, 2, 3, 4, 5];
+      const url = 'https://example.com/put-test.png';
+
+      final file = await manager.putFile(url, bytes, fileExtension: 'png');
+      final readBytes = await file.readAsBytes();
+      expect(readBytes, bytes);
+
+      final cached = await manager.getFileFromCache(url);
+      expect(cached, isNotNull);
+      expect(cached!.originalUrl, url);
+      expect(cached.source, FileSource.Cache);
+
+      final cachedBytes = await cached.file.readAsBytes();
+      expect(cachedBytes, bytes);
+    });
+
+    test('putFile with custom key', () async {
+      const url = 'https://example.com/custom-key.png';
+      const key = 'my-custom-key';
+
+      await manager.putFile(url, [1, 2, 3], key: key, fileExtension: 'png');
+
+      // Retrieving by key should work
+      final cached = await manager.getFileFromCache(key);
+      expect(cached, isNotNull);
+      expect(cached!.originalUrl, url);
+
+      // Retrieving by URL should NOT work (key is different)
+      final byUrl = await manager.getFileFromCache(url);
+      expect(byUrl, isNull);
+    });
+
+    test('putFile with eTag stores metadata', () async {
+      const url = 'https://example.com/etag-test.png';
+      await manager.putFile(
+        url,
+        [1, 2, 3],
+        eTag: '"test-etag-123"',
+        fileExtension: 'png',
+      );
+      final cached = await manager.getFileFromCache(url);
+      expect(cached, isNotNull);
+    });
+
+    test('putFile with custom maxAge', () async {
+      const url = 'https://example.com/maxage.png';
+      await manager.putFile(
+        url,
+        [1, 2, 3],
+        maxAge: const Duration(hours: 1),
+        fileExtension: 'png',
+      );
+
+      final cached = await manager.getFileFromCache(url);
+      expect(cached, isNotNull);
+      expect(cached!.validTill.isAfter(DateTime.now()), isTrue);
+      // Should expire within ~1 hour, not 30 days
+      expect(
+        cached.validTill.isBefore(
+          DateTime.now().add(const Duration(hours: 2)),
+        ),
+        isTrue,
+      );
+    });
+
+    test('putFile overwrites existing entry', () async {
+      const url = 'https://example.com/overwrite.png';
+
+      await manager.putFile(url, [1, 2, 3], fileExtension: 'png');
+      await manager.putFile(url, [4, 5, 6, 7], fileExtension: 'png');
+
+      final cached = await manager.getFileFromCache(url);
+      expect(cached, isNotNull);
+      final bytes = await cached!.file.readAsBytes();
+      expect(bytes, [4, 5, 6, 7]);
+    });
+
+    test('getFileFromCache returns null for non-existent key', () async {
+      final cached = await manager.getFileFromCache('non-existent-key');
+      expect(cached, isNull);
+    });
+
+    test('removeFile deletes the entry', () async {
+      const url = 'https://example.com/remove-test.png';
+      await manager.putFile(url, [1, 2, 3], fileExtension: 'png');
+
+      final cached = await manager.getFileFromCache(url);
+      expect(cached, isNotNull);
+
+      await manager.removeFile(url);
+
+      final afterRemove = await manager.getFileFromCache(url);
+      expect(afterRemove, isNull);
+    });
+
+    test('emptyCache clears all entries', () async {
+      await manager.putFile(
+        'https://example.com/empty-1.png',
+        [1],
+        fileExtension: 'png',
+      );
+      await manager.putFile(
+        'https://example.com/empty-2.png',
+        [2],
+        fileExtension: 'png',
+      );
+
+      await manager.emptyCache();
+
+      expect(
+        await manager.getFileFromCache('https://example.com/empty-1.png'),
+        isNull,
+      );
+      expect(
+        await manager.getFileFromCache('https://example.com/empty-2.png'),
+        isNull,
+      );
+    });
+  });
+
+  // =====================================================================
+  // getFileStream — download, cache hit, progress, errors
+  // =====================================================================
+
+  group('WebCacheManager getFileStream', () {
+    test('downloads and caches a file on first request', () async {
+      final responseData = List.generate(100, (i) => i % 256);
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response.bytes(responseData, 200),
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/download.png')
+          .toList();
+
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, hasLength(1));
+      expect(fileInfos.first.source, FileSource.Online);
+
+      final bytes = await fileInfos.first.file.readAsBytes();
+      expect(bytes, responseData);
+
+      // Second request should return from cache
+      final events2 = await manager
+          .getFileStream('https://example.com/download.png')
+          .toList();
+      final fileInfos2 = events2.whereType<FileInfo>().toList();
+      expect(fileInfos2.isNotEmpty, isTrue);
+      // First event should be from cache
+      expect(fileInfos2.first.source, FileSource.Cache);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('reports download progress when withProgress is true', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            final controller = StreamController<List<int>>();
+            controller.add([1, 2, 3]);
+            controller.add([4, 5, 6]);
+            controller.add([7, 8, 9]);
+            controller.close();
+            return http.StreamedResponse(
+              controller.stream,
+              200,
+              contentLength: 9,
+            );
+          },
+        ),
+      );
+
+      final events = await manager
+          .getFileStream(
+            'https://example.com/progress.png',
+            withProgress: true,
+          )
+          .toList();
+
+      final progressEvents = events.whereType<DownloadProgress>().toList();
+      expect(progressEvents, isNotEmpty);
+      // Last progress should have received 9 bytes
+      expect(progressEvents.last.downloaded, 9);
+      expect(progressEvents.last.totalSize, 9);
+
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, hasLength(1));
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('does not report progress when withProgress is false', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('abc', 200),
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/no-progress.png')
+          .toList();
+
+      final progressEvents = events.whereType<DownloadProgress>().toList();
+      expect(progressEvents, isEmpty);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('throws HttpExceptionWithStatus on non-200 response', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('not found', 404),
+        ),
+      );
+
+      Object? error;
+      try {
+        await manager
+            .getFileStream('https://example.com/not-found.png')
+            .toList();
+      } on Object catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<HttpExceptionWithStatus>());
+      expect((error! as HttpExceptionWithStatus).statusCode, 404);
+
+      await manager.dispose();
+    });
+
+    test('throws on 500 status', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('error', 500),
+        ),
+      );
+
+      Object? error;
+      try {
+        await manager
+            .getFileStream('https://example.com/server-error.png')
+            .toList();
+      } on Object catch (e) {
+        error = e;
+      }
+
+      expect(error, isA<HttpExceptionWithStatus>());
+      expect((error! as HttpExceptionWithStatus).statusCode, 500);
+
+      await manager.dispose();
+    });
+
+    test('forwards custom headers to HTTP request', () async {
+      Map<String, String>? receivedHeaders;
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async {
+            receivedHeaders = request.headers;
+            return http.Response('ok', 200);
+          },
+        ),
+      );
+
+      await manager
+          .getFileStream(
+            'https://example.com/headers.png',
+            headers: {'Authorization': 'Bearer token123'},
+          )
+          .toList();
+
+      expect(receivedHeaders, isNotNull);
+      expect(receivedHeaders!['Authorization'], 'Bearer token123');
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('uses custom key when provided', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('data', 200),
+        ),
+      );
+
+      await manager
+          .getFileStream(
+            'https://example.com/keyed.png',
+            key: 'my-stream-key',
+          )
+          .toList();
+
+      // Should be cached under the custom key
+      final cached = await manager.getFileFromCache('my-stream-key');
+      expect(cached, isNotNull);
+
+      // The original URL key should NOT have data
+      final byUrl =
+          await manager.getFileFromCache('https://example.com/keyed.png');
+      expect(byUrl, isNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('serves stale cache then redownloads', () async {
+      var downloadCount = 0;
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        stalePeriod: Duration.zero, // Everything expires immediately
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async {
+            downloadCount++;
+            return http.Response('data-$downloadCount', 200);
+          },
+        ),
+      );
+
+      // First request — download
+      await manager
+          .getFileStream('https://example.com/stale.png')
+          .toList();
+      expect(downloadCount, 1);
+
+      // Wait a tiny bit to ensure stalePeriod (zero) has passed
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Second request — should serve stale cache AND redownload
+      final events2 = await manager
+          .getFileStream('https://example.com/stale.png')
+          .toList();
+      expect(downloadCount, 2);
+
+      // Should have two FileInfo events: one from cache, one from download
+      final fileInfos = events2.whereType<FileInfo>().toList();
+      expect(fileInfos.length, greaterThanOrEqualTo(1));
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // =====================================================================
+  // getImageFile — resize key behavior on web
+  // =====================================================================
+
+  group('WebCacheManager getImageFile', () {
+    test('delegates to getFileStream when no resize params', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('image-bytes', 200),
+        ),
+      );
+
+      final events = await manager
+          .getImageFile('https://example.com/image.png')
+          .toList();
+
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, hasLength(1));
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('stores original under resized key when maxWidth is set', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('original-image', 200),
+        ),
+      );
+
+      final events = await manager
+          .getImageFile(
+            'https://example.com/resize.png',
+            maxWidth: 300,
+          )
+          .toList();
+
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, hasLength(1));
+
+      // The resized key should exist in cache
+      final resizedCached = await manager.getFileFromCache(
+        'resized_w300_https://example.com/resize.png',
+      );
+      expect(resizedCached, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('stores original under resized key when maxHeight is set', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('original-image', 200),
+        ),
+      );
+
+      await manager
+          .getImageFile(
+            'https://example.com/resize-h.png',
+            maxHeight: 200,
+          )
+          .toList();
+
+      final resizedCached = await manager.getFileFromCache(
+        'resized_h200_https://example.com/resize-h.png',
+      );
+      expect(resizedCached, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('builds correct resized key with both width and height', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('img', 200),
+        ),
+      );
+
+      await manager
+          .getImageFile(
+            'https://example.com/both.png',
+            maxWidth: 400,
+            maxHeight: 300,
+          )
+          .toList();
+
+      final cached = await manager.getFileFromCache(
+        'resized_w400_h300_https://example.com/both.png',
+      );
+      expect(cached, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('returns cached resized entry on second call', () async {
+      var downloadCount = 0;
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async {
+            downloadCount++;
+            return http.Response('img-data', 200);
+          },
+        ),
+      );
+
+      await manager
+          .getImageFile(
+            'https://example.com/cached-resize.png',
+            maxWidth: 100,
+          )
+          .toList();
+      expect(downloadCount, 1);
+
+      // Second call should use cache
+      final events = await manager
+          .getImageFile(
+            'https://example.com/cached-resize.png',
+            maxWidth: 100,
+          )
+          .toList();
+
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos.first.source, FileSource.Cache);
+      // Should NOT download again
+      expect(downloadCount, 1);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // =====================================================================
+  // Concurrent initialization
+  // =====================================================================
+
+  group('WebCacheManager concurrent initialization', () {
+    test('parallel putFile calls on cold manager all succeed', () async {
+      final manager = DefaultCacheManager(hiveInstance: testHive);
+
+      final futures = List.generate(
+        10,
+        (i) => manager.putFile(
+          'https://example.com/web-concurrent-$i.png',
+          List.filled(i + 1, i),
+          fileExtension: 'png',
+        ),
+      );
+
+      await Future.wait(futures);
+
+      for (var i = 0; i < 10; i++) {
+        final cached = await manager.getFileFromCache(
+          'https://example.com/web-concurrent-$i.png',
+        );
+        expect(cached, isNotNull, reason: 'Entry $i should be cached');
+        final bytes = await cached!.file.readAsBytes();
+        expect(bytes.length, i + 1, reason: 'Entry $i has wrong length');
+      }
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('mixed concurrent operations on cold manager', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('img', 200),
+        ),
+      );
+
+      final futures = <Future>[
+        manager.putFile(
+          'https://example.com/web-mix-put.png',
+          [1],
+          fileExtension: 'png',
+        ),
+        manager.getFileFromCache('https://example.com/non-existent'),
+        manager
+            .getFileStream('https://example.com/web-mix-stream.png')
+            .toList(),
+        manager.removeFile('https://example.com/also-non-existent'),
+      ];
+
+      await Future.wait(futures);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // =====================================================================
+  // Dispose / lifecycle
+  // =====================================================================
+
+  group('WebCacheManager dispose lifecycle', () {
+    test('dispose closes boxes', () async {
+      final manager = DefaultCacheManager(hiveInstance: testHive);
+      await manager.putFile(
+        'https://example.com/web-dispose.png',
+        [1, 2, 3],
+        fileExtension: 'png',
+      );
+      await manager.dispose();
+
+      // Re-opening should work
+      final manager2 = DefaultCacheManager(hiveInstance: testHive);
+      final cached = await manager2.getFileFromCache(
+        'https://example.com/web-dispose.png',
+      );
+      expect(cached, isNotNull);
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+
+    test('double dispose does not throw', () async {
+      final manager = DefaultCacheManager(hiveInstance: testHive);
+      await manager.putFile(
+        'https://example.com/web-double-dispose.png',
+        [1, 2],
+        fileExtension: 'png',
+      );
+
+      await manager.dispose();
+      await manager.dispose();
+    });
+
+    test('emptyCache followed by dispose is safe', () async {
+      final manager = DefaultCacheManager(hiveInstance: testHive);
+      await manager.putFile(
+        'https://example.com/web-empty-dispose.png',
+        [1, 2, 3],
+        fileExtension: 'png',
+      );
+
+      await manager.emptyCache();
+      await manager.dispose();
+
+      final manager2 = DefaultCacheManager(hiveInstance: testHive);
+      final cached = await manager2.getFileFromCache(
+        'https://example.com/web-empty-dispose.png',
+      );
+      expect(cached, isNull);
+
+      await manager2.dispose();
+    });
+
+    test('operations after dispose re-initialize gracefully', () async {
+      final manager = DefaultCacheManager(hiveInstance: testHive);
+      await manager.putFile(
+        'https://example.com/web-reuse.png',
+        [1],
+        fileExtension: 'png',
+      );
+      await manager.dispose();
+
+      // Using the manager after dispose should re-initialize
+      final cached = await manager.getFileFromCache(
+        'https://example.com/web-reuse.png',
+      );
+      expect(cached, isNotNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // =====================================================================
+  // Cleanup / eviction
+  // =====================================================================
+
+  group('WebCacheManager cleanup', () {
+    test('enforces maxNrOfCacheObjects by evicting oldest entries', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        maxNrOfCacheObjects: 3,
+        stalePeriod: const Duration(days: 1),
+      );
+
+      // Add 5 entries with staggered validTill
+      for (var i = 0; i < 5; i++) {
+        await manager.putFile(
+          'https://example.com/cleanup-$i.png',
+          [i],
+          maxAge: Duration(hours: i + 1),
+          fileExtension: 'png',
+        );
+      }
+
+      // Trigger cleanup by disposing and re-creating
+      await manager.dispose();
+      final manager2 = DefaultCacheManager(hiveInstance: testHive, maxNrOfCacheObjects: 3);
+
+      // The newest 3 entries should survive, oldest 2 may be cleaned up
+      // (cleanup runs in background on init, we need to wait a moment)
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      // At minimum, the newest entries should be available
+      final newest = await manager2.getFileFromCache(
+        'https://example.com/cleanup-4.png',
+      );
+      expect(newest, isNotNull);
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+  });
+
+
+
+  // =====================================================================
+  // StreamController / http.Client lifecycle (leak checks)
+  // =====================================================================
+
+  group('WebCacheManager leak checks', () {
+    test('StreamController is closed after successful download', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('data', 200),
+        ),
+      );
+
+      final stream =
+          manager.getFileStream('https://example.com/web-leak-ok.png');
+      final events = await stream.toList();
+      expect(events.whereType<FileInfo>().isNotEmpty, isTrue);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('StreamController is closed after HTTP error', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('err', 500),
+        ),
+      );
+
+      Object? error;
+      try {
+        await manager
+            .getFileStream('https://example.com/web-leak-err.png')
+            .toList();
+      } on Object catch (e) {
+        error = e;
+      }
+
+      expect(error, isNotNull);
+      await manager.dispose();
+    });
+
+    test('http.Client is closed after successful download', () async {
+      var clientClosed = false;
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () {
+          final mock = http_testing.MockClient(
+            (request) async => http.Response('ok', 200),
+          );
+          return _CloseTrackingClient(mock, onClose: () {
+            clientClosed = true;
+          });
+        },
+      );
+
+      await manager
+          .getFileStream('https://example.com/web-client-ok.png')
+          .toList();
+
+      expect(clientClosed, isTrue,
+          reason: 'http.Client must be closed after download');
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+
+    test('http.Client is closed after HTTP error', () async {
+      var clientClosed = false;
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () {
+          final mock = http_testing.MockClient(
+            (request) async => http.Response('fail', 500),
+          );
+          return _CloseTrackingClient(mock, onClose: () {
+            clientClosed = true;
+          });
+        },
+      );
+
+      try {
+        await manager
+            .getFileStream('https://example.com/web-client-err.png')
+            .toList();
+      } on Object catch (_) {}
+
+      expect(clientClosed, isTrue,
+          reason: 'http.Client must be closed even on error');
+
+      await manager.dispose();
+    });
+  });
+}
+
+/// A wrapper around [http.Client] that tracks whether [close] was called.
+class _CloseTrackingClient extends http.BaseClient {
+  _CloseTrackingClient(this._inner, {required this.onClose});
+
+  final http.Client _inner;
+  final void Function() onClose;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    onClose();
+    _inner.close();
+  }
+}

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -730,8 +730,20 @@ void main() {
           DefaultCacheManager(hiveInstance: testHive, maxNrOfCacheObjects: 3);
 
       // The newest 3 entries should survive, oldest 2 may be cleaned up
-      // (cleanup runs in background on init, we need to wait a moment)
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      // (cleanup runs in background on init, wait until it finishes via polling)
+      bool cleanupSuccess = false;
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        final oldest = await manager2.getFileFromCache(
+          'https://example.com/cleanup-0.png',
+        );
+        if (oldest == null) {
+          cleanupSuccess = true;
+          break;
+        }
+      }
+
+      expect(cleanupSuccess, isTrue, reason: 'Background cleanup failed or timed out');
 
       // At minimum, the newest entries should be available
       final newest = await manager2.getFileFromCache(

--- a/cached_network_image/test/leak_test.dart
+++ b/cached_network_image/test/leak_test.dart
@@ -10,7 +10,9 @@ import 'dart:async';
 import 'dart:io' as io;
 import 'dart:ui' as ui;
 
-import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:cached_network_image_ce/cached_network_image.dart'
+    hide DefaultCacheManager;
+import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
 import 'package:cached_network_image_ce/src/image_provider/_image_loader.dart';
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart'
     hide ImageLoader;

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -4,7 +4,7 @@ library cached_network_image_web_ce;
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
-import 'dart:ui_web';
+import 'dart:ui_web' as ui_web;
 
 import 'package:cached_network_image_platform_interface_ce'
         '/cached_network_image_platform_interface_ce.dart' as platform
@@ -36,7 +36,12 @@ class ImageLoader implements platform.ImageLoader {
       chunkEvents,
       (bytes) async {
         final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
-        return decode(buffer);
+        return decode(
+          buffer,
+          cacheWidth: maxWidth,
+          cacheHeight: maxHeight,
+          allowUpscaling: false,
+        );
       },
       cacheManager,
       maxHeight,
@@ -66,7 +71,21 @@ class ImageLoader implements platform.ImageLoader {
       chunkEvents,
       (bytes) async {
         final buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
-        return decode(buffer);
+        return decode(
+          buffer,
+          getTargetSize: (int intrinsicWidth, int intrinsicHeight) {
+            if (maxWidth == null && maxHeight == null) {
+              return ui.TargetImageSize(
+                width: intrinsicWidth,
+                height: intrinsicHeight,
+              );
+            }
+            return ui.TargetImageSize(
+              width: maxWidth,
+              height: maxHeight,
+            );
+          },
+        );
       },
       cacheManager,
       maxHeight,
@@ -204,7 +223,7 @@ class ImageLoader implements platform.ImageLoader {
   ) {
     final resolved = Uri.base.resolve(url);
     // ignore: undefined_function
-    return createImageCodecFromUrl(
+    return ui_web.createImageCodecFromUrl(
       resolved,
       chunkCallback: (int bytes, int total) {
         chunkEvents.add(


### PR DESCRIPTION
## Description

Introduce persistent web caching using Hive CE, enabling full support for Flutter web applications. Update documentation to reflect true web capabilities and enhance the FAQ section. Enable the hive_ce extension in DevTools and bump the version to 4.5.0.

## Related Issues

https://github.com/Baseflow/flutter_cached_network_image/issues/823
https://github.com/Baseflow/flutter_cached_network_image/issues/745
https://github.com/Baseflow/flutter_cached_network_image/issues/720

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * True web support with persistent image caching via IndexedDB so images persist across sessions and reduce RAM freezes.

* **Improvements**
  * Web image decoding honors target sizes and avoids upscaling for better performance and memory usage.
  * Platform-specific cache behavior refined for more reliable web caching, eviction, and compile-time selection of implementations.

* **Documentation**
  * README, FAQ, and changelog updated; installation guidance switched to package add and FAQ explains web vs IO behavior and Image.network alternative.
  * Contributing link updated to local file path.

* **Tests**
  * Added comprehensive web cache manager tests covering caching, downloads, progress, resizing, eviction, and lifecycle.

* **Chores**
  * Devtools options enabled hive_ce extension; package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->