### PR TITLE
Add connection timeout support to cache managers

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.6.0] - 2026-03-03
+
+* **Feature:** Added optional HTTP timeout support via `ConnectionParameters` on `DefaultCacheManager`.
+  * `connectionTimeout` limits time waiting for response headers.
+  * `requestTimeout` applies an inactivity timeout while streaming response bytes.
+  * Existing behavior is preserved when `connectionParameters` is not provided.
+* Added tests for timeout behavior and client cleanup on timeout.
+
 ## [4.5.0] - 2026-03-02
 
 * **Feature:** Added web platform support. The package can now be used in Flutter web apps.

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -119,16 +119,16 @@ You can configure network timeouts at the cache manager level using
 
 ```dart
 final cacheManager = DefaultCacheManager(
-  connectionParameters: const ConnectionParameters(
-    connectionTimeout: Duration(seconds: 10),
-    requestTimeout: Duration(seconds: 30),
+  connectionParameters: ConnectionParameters(
+    connectionTimeout: const Duration(seconds: 10),
+    requestTimeout: const Duration(seconds: 30),
   ),
 );
 
 CachedNetworkImage(
   imageUrl: 'https://example.com/image.jpg',
   cacheManager: cacheManager,
-  errorWidget: (context, url, error) => const Icon(Icons.error),
+  errorBuilder: (context, url, error) => const Icon(Icons.error),
 )
 ```
 

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -112,6 +112,38 @@ CachedNetworkImage(
 Image(image: CachedNetworkImageProvider(url))
 ```
 
+### Network Timeouts (DefaultCacheManager)
+
+You can configure network timeouts at the cache manager level using
+`ConnectionParameters`.
+
+```dart
+final cacheManager = DefaultCacheManager(
+  connectionParameters: const ConnectionParameters(
+    connectionTimeout: Duration(seconds: 10),
+    requestTimeout: Duration(seconds: 30),
+  ),
+);
+
+CachedNetworkImage(
+  imageUrl: 'https://example.com/image.jpg',
+  cacheManager: cacheManager,
+  errorWidget: (context, url, error) => const Icon(Icons.error),
+)
+```
+
+Timeout behavior:
+
+* `connectionTimeout`: max time waiting for response headers.
+* `requestTimeout`: inactivity timeout while streaming response bytes.
+
+Both fields are optional and nullable. If `connectionParameters` is not
+provided, existing behavior is preserved (no timeout is applied).
+
+On Flutter Web, timeout settings apply when using
+`ImageRenderMethodForWeb.HttpGet`. The `HtmlImage` render method uses the
+browser image pipeline and bypasses the cache manager HTTP path.
+
 ### SVG Support
 
 Flutter's built-in image codec doesn't support SVG. When `CachedNetworkImage`

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -293,10 +293,6 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
             await tempFile.rename(filePath);
             movedToFinalPath = true;
-
-            if (backupFile != null && await backupFile.exists()) {
-              await backupFile.delete();
-            }
           } on Object catch (_) {
             if (backupFile != null && await backupFile.exists()) {
               if (await finalFile.exists()) {
@@ -305,6 +301,17 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
               await backupFile.rename(filePath);
             }
             rethrow;
+          }
+
+          if (backupFile != null && await backupFile.exists()) {
+            try {
+              await backupFile.delete();
+            } on Object catch (e) {
+              cacheLogger.log(
+                'CacheManager: Failed to delete backup file for $filePath with error:\n$e',
+                CacheManagerLogLevel.warning,
+              );
+            }
           }
         }
       } on Object catch (_) {

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -255,8 +255,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final fileExtension = _getFileExtensionFromUrl(url);
       final relativePath = _generateRelativePath(key, fileExtension);
       final filePath = _cacheFilePath(relativePath);
-      final file = io.File(filePath);
-      final sink = file.openWrite();
+      final tempFilePath = '$filePath.${DateTime.now().microsecondsSinceEpoch}.tmp';
+      final tempFile = io.File(tempFilePath);
+      final sink = tempFile.openWrite();
 
       final requestTimeout = connectionParameters?.requestTimeout;
       final stream = requestTimeout != null
@@ -264,6 +265,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
           : response.stream;
 
       var receivedBytes = 0;
+      var movedToFinalPath = false;
       try {
         await for (final chunk in stream) {
           receivedBytes += chunk.length;
@@ -274,9 +276,20 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         }
         await sink.flush();
         await sink.close();
+
+        final finalFile = io.File(filePath);
+        if (await finalFile.exists()) {
+          await finalFile.delete();
+        }
+        await tempFile.rename(filePath);
+        movedToFinalPath = true;
       } on Object catch (_) {
         await sink.close();
         rethrow;
+      } finally {
+        if (!movedToFinalPath && await tempFile.exists()) {
+          await tempFile.delete();
+        }
       }
 
       // Store metadata in Hive

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -279,11 +279,34 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         await sink.close();
 
         final finalFile = io.File(filePath);
-        if (await finalFile.exists()) {
-          await finalFile.delete();
+        try {
+          await tempFile.rename(filePath);
+          movedToFinalPath = true;
+        } on Object catch (_) {
+          io.File? backupFile;
+          try {
+            if (await finalFile.exists()) {
+              final backupPath =
+                  '$filePath.${DateTime.now().microsecondsSinceEpoch}.bak';
+              backupFile = await finalFile.rename(backupPath);
+            }
+
+            await tempFile.rename(filePath);
+            movedToFinalPath = true;
+
+            if (backupFile != null && await backupFile.exists()) {
+              await backupFile.delete();
+            }
+          } on Object catch (_) {
+            if (backupFile != null && await backupFile.exists()) {
+              if (await finalFile.exists()) {
+                await finalFile.delete();
+              }
+              await backupFile.rename(filePath);
+            }
+            rethrow;
+          }
         }
-        await tempFile.rename(filePath);
-        movedToFinalPath = true;
       } on Object catch (_) {
         await sink.close();
         rethrow;

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -255,7 +255,8 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final fileExtension = _getFileExtensionFromUrl(url);
       final relativePath = _generateRelativePath(key, fileExtension);
       final filePath = _cacheFilePath(relativePath);
-      final tempFilePath = '$filePath.${DateTime.now().microsecondsSinceEpoch}.tmp';
+      final tempFilePath =
+          '$filePath.${DateTime.now().microsecondsSinceEpoch}.tmp';
       final tempFile = io.File(tempFilePath);
       final sink = tempFile.openWrite();
 

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -45,6 +45,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   DefaultCacheManager({
     this.stalePeriod = _kDefaultStalePeriod,
     this.maxNrOfCacheObjects = _kDefaultMaxCacheObjects,
+    this.connectionParameters,
     http.Client Function()? httpClientFactory,
     CacheDirectoryProvider? cacheDirectoryProvider,
   })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
@@ -56,6 +57,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
   /// Maximum number of objects in the cache before cleanup.
   final int maxNrOfCacheObjects;
+
+  /// Optional connection parameters for HTTP timeouts.
+  ///
+  /// When `null` (the default), no timeouts are applied and downloads may
+  /// wait indefinitely — preserving the existing behaviour.
+  final ConnectionParameters? connectionParameters;
 
   /// Factory for creating HTTP clients (injectable for testing).
   final http.Client Function() _httpClientFactory;
@@ -231,7 +238,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
     final client = _httpClientFactory();
     try {
-      final response = await client.send(request);
+      final connectionTimeout = connectionParameters?.connectionTimeout;
+      final response = connectionTimeout != null
+          ? await client.send(request).timeout(connectionTimeout)
+          : await client.send(request);
 
       if (response.statusCode != 200 && response.statusCode != 202) {
         throw HttpExceptionWithStatus(
@@ -248,9 +258,14 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final file = io.File(filePath);
       final sink = file.openWrite();
 
+      final requestTimeout = connectionParameters?.requestTimeout;
+      final stream = requestTimeout != null
+          ? response.stream.timeout(requestTimeout)
+          : response.stream;
+
       var receivedBytes = 0;
       try {
-        await for (final chunk in response.stream) {
+        await for (final chunk in stream) {
           receivedBytes += chunk.length;
           sink.add(chunk);
           if (withProgress) {

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -35,6 +35,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   DefaultCacheManager({
     this.stalePeriod = _kDefaultStalePeriod,
     this.maxNrOfCacheObjects = _kDefaultMaxCacheObjects,
+    this.connectionParameters,
     http.Client Function()? httpClientFactory,
     @visibleForTesting HiveInterface? hiveInstance,
   })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
@@ -45,6 +46,17 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
   /// Maximum number of objects in the cache before cleanup.
   final int maxNrOfCacheObjects;
+
+  /// Optional connection parameters for HTTP timeouts.
+  ///
+  /// When `null` (the default), no timeouts are applied and downloads may
+  /// wait indefinitely — preserving the existing behaviour.
+  ///
+  /// **Note:** On the web platform, timeouts only apply when using
+  /// [ImageRenderMethodForWeb.HttpGet]. The [ImageRenderMethodForWeb.HtmlImage]
+  /// render path bypasses the cache manager's HTTP layer entirely and is
+  /// handled by the browser.
+  final ConnectionParameters? connectionParameters;
 
   /// Factory for creating HTTP clients.
   final http.Client Function() _httpClientFactory;
@@ -208,7 +220,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
     final client = _httpClientFactory();
     try {
-      final response = await client.send(request);
+      final connectionTimeout = connectionParameters?.connectionTimeout;
+      final response = connectionTimeout != null
+          ? await client.send(request).timeout(connectionTimeout)
+          : await client.send(request);
 
       if (response.statusCode != 200 && response.statusCode != 202) {
         throw HttpExceptionWithStatus(
@@ -222,7 +237,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final allBytes = <int>[];
       var receivedBytes = 0;
 
-      await for (final chunk in response.stream) {
+      final requestTimeout = connectionParameters?.requestTimeout;
+      final stream = requestTimeout != null
+          ? response.stream.timeout(requestTimeout)
+          : response.stream;
+
+      await for (final chunk in stream) {
         receivedBytes += chunk.length;
         allBytes.addAll(chunk);
         if (withProgress) {

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.5.0
+version: 4.6.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  cached_network_image_platform_interface_ce: ^5.1.0
+  cached_network_image_platform_interface_ce: ^5.2.0
   cached_network_image_web_ce: ^2.1.0
   file: '>=7.0.0 <8.0.0'
   flutter:

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1350,9 +1350,9 @@ void main() {
 
     test('accepts connectionParameters', () {
       manager = DefaultCacheManager(
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(seconds: 10),
-          requestTimeout: Duration(seconds: 30),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(seconds: 10),
+          requestTimeout: const Duration(seconds: 30),
         ),
       );
       expect(manager.connectionParameters, isNotNull);
@@ -1369,8 +1369,8 @@ void main() {
     test('connectionTimeout triggers TimeoutException when server is slow',
         () async {
       manager = DefaultCacheManager(
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(milliseconds: 100),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(milliseconds: 100),
         ),
         httpClientFactory: () => http_testing.MockClient.streaming(
           (request, bodyStream) async {
@@ -1389,8 +1389,8 @@ void main() {
     test('requestTimeout triggers TimeoutException when stream stalls',
         () async {
       manager = DefaultCacheManager(
-        connectionParameters: const ConnectionParameters(
-          requestTimeout: Duration(milliseconds: 100),
+        connectionParameters: ConnectionParameters(
+          requestTimeout: const Duration(milliseconds: 100),
         ),
         httpClientFactory: () => http_testing.MockClient.streaming(
           (request, bodyStream) async {
@@ -1427,9 +1427,9 @@ void main() {
 
     test('successful download with connectionParameters set', () async {
       manager = DefaultCacheManager(
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(seconds: 5),
-          requestTimeout: Duration(seconds: 5),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(seconds: 5),
+          requestTimeout: const Duration(seconds: 5),
         ),
         httpClientFactory: () => http_testing.MockClient(
           (request) async => http.Response('image-data', 200),
@@ -1447,8 +1447,8 @@ void main() {
       var clientClosed = false;
 
       manager = DefaultCacheManager(
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(milliseconds: 50),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(milliseconds: 50),
         ),
         httpClientFactory: () {
           final inner = http_testing.MockClient.streaming(

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1330,4 +1330,168 @@ void main() {
       expect(reconstructed.length, original.length);
     });
   });
+
+  // ---- ConnectionParameters / timeout tests ----
+
+  group('DefaultCacheManager with ConnectionParameters', () {
+    late DefaultCacheManager manager;
+
+    tearDown(() async {
+      try {
+        await manager.emptyCache();
+        await manager.dispose();
+      } on Object catch (_) {}
+    });
+
+    test('connectionParameters defaults to null', () {
+      manager = DefaultCacheManager();
+      expect(manager.connectionParameters, isNull);
+    });
+
+    test('accepts connectionParameters', () {
+      manager = DefaultCacheManager(
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(seconds: 10),
+          requestTimeout: Duration(seconds: 30),
+        ),
+      );
+      expect(manager.connectionParameters, isNotNull);
+      expect(
+        manager.connectionParameters!.connectionTimeout,
+        const Duration(seconds: 10),
+      );
+      expect(
+        manager.connectionParameters!.requestTimeout,
+        const Duration(seconds: 30),
+      );
+    });
+
+    test('connectionTimeout triggers TimeoutException when server is slow',
+        () async {
+      manager = DefaultCacheManager(
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(milliseconds: 100),
+        ),
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            // Simulate a server that never responds.
+            await Future<void>.delayed(const Duration(seconds: 10));
+            return http.StreamedResponse(const Stream.empty(), 200);
+          },
+        ),
+      );
+
+      final stream =
+          manager.getFileStream('https://example.com/slow-connect.png');
+      await expectLater(stream, emitsError(isA<TimeoutException>()));
+    });
+
+    test('requestTimeout triggers TimeoutException when stream stalls',
+        () async {
+      manager = DefaultCacheManager(
+        connectionParameters: const ConnectionParameters(
+          requestTimeout: Duration(milliseconds: 100),
+        ),
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            final controller = StreamController<List<int>>();
+            // Send one chunk then stall indefinitely.
+            controller.add([1, 2, 3, 4]);
+            // Never close the controller — simulates a stalled transfer.
+            return http.StreamedResponse(
+              controller.stream,
+              200,
+              contentLength: 100,
+            );
+          },
+        ),
+      );
+
+      final stream =
+          manager.getFileStream('https://example.com/stalled.png');
+      await expectLater(stream, emitsError(isA<TimeoutException>()));
+    });
+
+    test('no timeout when connectionParameters is null', () async {
+      manager = DefaultCacheManager(
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('data', 200),
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/no-timeout.dat')
+          .toList();
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, isNotEmpty);
+    });
+
+    test('successful download with connectionParameters set', () async {
+      manager = DefaultCacheManager(
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(seconds: 5),
+          requestTimeout: Duration(seconds: 5),
+        ),
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('image-data', 200),
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/fast.png')
+          .toList();
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, isNotEmpty);
+      expect(fileInfos.first.source.name, 'Online');
+    });
+
+    test('client is closed even when connectionTimeout fires', () async {
+      var clientClosed = false;
+
+      manager = DefaultCacheManager(
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(milliseconds: 50),
+        ),
+        httpClientFactory: () {
+          final inner = http_testing.MockClient.streaming(
+            (request, bodyStream) async {
+              await Future<void>.delayed(const Duration(seconds: 10));
+              return http.StreamedResponse(const Stream.empty(), 200);
+            },
+          );
+          return _TimeoutCloseTrackingClient(inner, onClose: () {
+            clientClosed = true;
+          });
+        },
+      );
+
+      try {
+        await manager
+            .getFileStream('https://example.com/close-test.png')
+            .toList();
+      } on Object catch (_) {}
+
+      expect(clientClosed, isTrue,
+          reason: 'http.Client must be closed even on timeout');
+    });
+  });
+}
+
+/// A wrapper around [http.Client] that tracks whether [close] was called.
+class _TimeoutCloseTrackingClient extends http.BaseClient {
+  _TimeoutCloseTrackingClient(this._inner, {required this.onClose});
+
+  final http.Client _inner;
+  final void Function() onClose;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _inner.send(request);
+  }
+
+  @override
+  void close() {
+    onClose();
+    _inner.close();
+  }
 }

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1407,8 +1407,7 @@ void main() {
         ),
       );
 
-      final stream =
-          manager.getFileStream('https://example.com/stalled.png');
+      final stream = manager.getFileStream('https://example.com/stalled.png');
       await expectLater(stream, emitsError(isA<TimeoutException>()));
     });
 
@@ -1437,9 +1436,8 @@ void main() {
         ),
       );
 
-      final events = await manager
-          .getFileStream('https://example.com/fast.png')
-          .toList();
+      final events =
+          await manager.getFileStream('https://example.com/fast.png').toList();
       final fileInfos = events.whereType<FileInfo>().toList();
       expect(fileInfos, isNotEmpty);
       expect(fileInfos.first.source.name, 'Online');

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -931,8 +931,7 @@ void main() {
         ),
       );
 
-      final stream =
-          manager.getFileStream('https://example.com/stalled.png');
+      final stream = manager.getFileStream('https://example.com/stalled.png');
       await expectLater(stream, emitsError(isA<TimeoutException>()));
     });
 
@@ -963,9 +962,8 @@ void main() {
         ),
       );
 
-      final events = await manager
-          .getFileStream('https://example.com/fast.png')
-          .toList();
+      final events =
+          await manager.getFileStream('https://example.com/fast.png').toList();
       final fileInfos = events.whereType<FileInfo>().toList();
       expect(fileInfos, isNotEmpty);
       expect(fileInfos.first.source.name, 'Online');

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -874,9 +874,9 @@ void main() {
     test('accepts connectionParameters', () {
       manager = DefaultCacheManager(
         hiveInstance: testHive,
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(seconds: 10),
-          requestTimeout: Duration(seconds: 30),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(seconds: 10),
+          requestTimeout: const Duration(seconds: 30),
         ),
       );
       expect(manager.connectionParameters, isNotNull);
@@ -894,8 +894,8 @@ void main() {
         () async {
       manager = DefaultCacheManager(
         hiveInstance: testHive,
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(milliseconds: 100),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(milliseconds: 100),
         ),
         httpClientFactory: () => http_testing.MockClient.streaming(
           (request, bodyStream) async {
@@ -914,8 +914,8 @@ void main() {
         () async {
       manager = DefaultCacheManager(
         hiveInstance: testHive,
-        connectionParameters: const ConnectionParameters(
-          requestTimeout: Duration(milliseconds: 100),
+        connectionParameters: ConnectionParameters(
+          requestTimeout: const Duration(milliseconds: 100),
         ),
         httpClientFactory: () => http_testing.MockClient.streaming(
           (request, bodyStream) async {
@@ -953,9 +953,9 @@ void main() {
     test('successful download with connectionParameters set', () async {
       manager = DefaultCacheManager(
         hiveInstance: testHive,
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(seconds: 5),
-          requestTimeout: Duration(seconds: 5),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(seconds: 5),
+          requestTimeout: const Duration(seconds: 5),
         ),
         httpClientFactory: () => http_testing.MockClient(
           (request) async => http.Response('image-data', 200),
@@ -974,8 +974,8 @@ void main() {
 
       manager = DefaultCacheManager(
         hiveInstance: testHive,
-        connectionParameters: const ConnectionParameters(
-          connectionTimeout: Duration(milliseconds: 50),
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(milliseconds: 50),
         ),
         httpClientFactory: () {
           final inner = http_testing.MockClient.streaming(

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -851,6 +851,157 @@ void main() {
       await manager.dispose();
     });
   });
+
+  // =====================================================================
+  // ConnectionParameters / timeout tests
+  // =====================================================================
+
+  group('WebCacheManager with ConnectionParameters', () {
+    late DefaultCacheManager manager;
+
+    tearDown(() async {
+      try {
+        await manager.emptyCache();
+        await manager.dispose();
+      } on Object catch (_) {}
+    });
+
+    test('connectionParameters defaults to null', () {
+      manager = DefaultCacheManager(hiveInstance: testHive);
+      expect(manager.connectionParameters, isNull);
+    });
+
+    test('accepts connectionParameters', () {
+      manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(seconds: 10),
+          requestTimeout: Duration(seconds: 30),
+        ),
+      );
+      expect(manager.connectionParameters, isNotNull);
+      expect(
+        manager.connectionParameters!.connectionTimeout,
+        const Duration(seconds: 10),
+      );
+      expect(
+        manager.connectionParameters!.requestTimeout,
+        const Duration(seconds: 30),
+      );
+    });
+
+    test('connectionTimeout triggers TimeoutException when server is slow',
+        () async {
+      manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(milliseconds: 100),
+        ),
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            await Future<void>.delayed(const Duration(seconds: 10));
+            return http.StreamedResponse(const Stream.empty(), 200);
+          },
+        ),
+      );
+
+      final stream =
+          manager.getFileStream('https://example.com/slow-connect.png');
+      await expectLater(stream, emitsError(isA<TimeoutException>()));
+    });
+
+    test('requestTimeout triggers TimeoutException when stream stalls',
+        () async {
+      manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        connectionParameters: const ConnectionParameters(
+          requestTimeout: Duration(milliseconds: 100),
+        ),
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            final controller = StreamController<List<int>>();
+            // Send one chunk then stall indefinitely.
+            controller.add([1, 2, 3, 4]);
+            return http.StreamedResponse(
+              controller.stream,
+              200,
+              contentLength: 100,
+            );
+          },
+        ),
+      );
+
+      final stream =
+          manager.getFileStream('https://example.com/stalled.png');
+      await expectLater(stream, emitsError(isA<TimeoutException>()));
+    });
+
+    test('no timeout when connectionParameters is null', () async {
+      manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('data', 200),
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/no-timeout.dat')
+          .toList();
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, isNotEmpty);
+    });
+
+    test('successful download with connectionParameters set', () async {
+      manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(seconds: 5),
+          requestTimeout: Duration(seconds: 5),
+        ),
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('image-data', 200),
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/fast.png')
+          .toList();
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, isNotEmpty);
+      expect(fileInfos.first.source.name, 'Online');
+    });
+
+    test('client is closed even when connectionTimeout fires', () async {
+      var clientClosed = false;
+
+      manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        connectionParameters: const ConnectionParameters(
+          connectionTimeout: Duration(milliseconds: 50),
+        ),
+        httpClientFactory: () {
+          final inner = http_testing.MockClient.streaming(
+            (request, bodyStream) async {
+              await Future<void>.delayed(const Duration(seconds: 10));
+              return http.StreamedResponse(const Stream.empty(), 200);
+            },
+          );
+          return _CloseTrackingClient(inner, onClose: () {
+            clientClosed = true;
+          });
+        },
+      );
+
+      try {
+        await manager
+            .getFileStream('https://example.com/close-test.png')
+            .toList();
+      } on Object catch (_) {}
+
+      expect(clientClosed, isTrue,
+          reason: 'http.Client must be closed even on timeout');
+    });
+  });
 }
 
 /// A wrapper around [http.Client] that tracks whether [close] was called.

--- a/cached_network_image_platform_interface/CHANGELOG.md
+++ b/cached_network_image_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.2.0] - 2026-03-03
+
+* **Feature:** Added `ConnectionParameters` configuration class.
+	* Includes optional `connectionTimeout` and `requestTimeout` fields.
+	* Enables cache managers to apply HTTP timeout behavior while preserving current behavior when omitted.
+
 ## [5.1.0] - 2026-02-23
 
 * **Feature:** Added `UnsupportedImageFormatException` for non-codec-decodable formats (e.g., SVG)

--- a/cached_network_image_platform_interface/README.md
+++ b/cached_network_image_platform_interface/README.md
@@ -1,1 +1,13 @@
-# cached_network_image_platform_interface
+# cached_network_image_platform_interface_ce
+
+Platform interface package for `cached_network_image_ce` and platform
+implementations.
+
+## Exposed API highlights
+
+* Base cache manager contracts (`BaseCacheManager`, `CacheManager`,
+  `ImageCacheManager`)
+* File response and progress models (`FileInfo`, `DownloadProgress`)
+* Error and format helpers (`HttpExceptionWithStatus`,
+  `UnsupportedImageFormatException`, `ImageFormatDetector`)
+* Network timeout configuration object (`ConnectionParameters`)

--- a/cached_network_image_platform_interface/lib/cached_network_image_platform_interface_ce.dart
+++ b/cached_network_image_platform_interface/lib/cached_network_image_platform_interface_ce.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'src/cache_manager.dart';
 
 export 'src/cache_manager.dart';
+export 'src/connection_parameters.dart';
 export 'src/file_response.dart';
 export 'src/http_exception.dart';
 export 'src/image_format_detector.dart';

--- a/cached_network_image_platform_interface/lib/src/connection_parameters.dart
+++ b/cached_network_image_platform_interface/lib/src/connection_parameters.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/foundation.dart' show immutable;
+
+/// Configuration for HTTP connection and request timeouts used by
+/// [DefaultCacheManager] when downloading files.
+///
+/// Both timeouts are optional. When the entire [ConnectionParameters] object
+/// is `null` (the default), the cache manager preserves its current behaviour
+/// of waiting indefinitely.
+///
+/// Example:
+/// ```dart
+/// DefaultCacheManager(
+///   connectionParameters: ConnectionParameters(
+///     connectionTimeout: Duration(seconds: 10),
+///     requestTimeout: Duration(seconds: 30),
+///   ),
+/// )
+/// ```
+@immutable
+class ConnectionParameters {
+  /// Creates connection parameters for the cache manager.
+  ///
+  /// [connectionTimeout] limits how long to wait for the server to respond
+  /// with headers (i.e. the TCP connection + TLS handshake + first response).
+  /// A [TimeoutException] is thrown if the server does not respond in time.
+  ///
+  /// [requestTimeout] limits how long to wait between consecutive data chunks
+  /// while streaming the response body. This is an *inactivity* timeout — it
+  /// does **not** cap the total download duration. A slow-but-progressing
+  /// download will never be interrupted. A [TimeoutException] is thrown if no
+  /// data arrives within the specified duration.
+  const ConnectionParameters({
+    this.connectionTimeout,
+    this.requestTimeout,
+  });
+
+  /// Maximum duration to wait for the server to respond with headers.
+  ///
+  /// When `null`, no connection timeout is applied.
+  final Duration? connectionTimeout;
+
+  /// Maximum duration to wait between consecutive data chunks during
+  /// the response stream.
+  ///
+  /// This is an *inactivity* (idle) timeout, not a total download timeout.
+  /// When `null`, no request timeout is applied.
+  final Duration? requestTimeout;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConnectionParameters &&
+          runtimeType == other.runtimeType &&
+          connectionTimeout == other.connectionTimeout &&
+          requestTimeout == other.requestTimeout;
+
+  @override
+  int get hashCode => Object.hash(connectionTimeout, requestTimeout);
+
+  @override
+  String toString() => 'ConnectionParameters('
+      'connectionTimeout: $connectionTimeout, '
+      'requestTimeout: $requestTimeout)';
+}

--- a/cached_network_image_platform_interface/lib/src/connection_parameters.dart
+++ b/cached_network_image_platform_interface/lib/src/connection_parameters.dart
@@ -29,10 +29,25 @@ class ConnectionParameters {
   /// does **not** cap the total download duration. A slow-but-progressing
   /// download will never be interrupted. A [TimeoutException] is thrown if no
   /// data arrives within the specified duration.
-  const ConnectionParameters({
+  ConnectionParameters({
     this.connectionTimeout,
     this.requestTimeout,
-  });
+  }) {
+    if (connectionTimeout != null && connectionTimeout!.isNegative) {
+      throw ArgumentError.value(
+        connectionTimeout,
+        'connectionTimeout',
+        'Must be greater than or equal to zero.',
+      );
+    }
+    if (requestTimeout != null && requestTimeout!.isNegative) {
+      throw ArgumentError.value(
+        requestTimeout,
+        'requestTimeout',
+        'Must be greater than or equal to zero.',
+      );
+    }
+  }
 
   /// Maximum duration to wait for the server to respond with headers.
   ///

--- a/cached_network_image_platform_interface/pubspec.yaml
+++ b/cached_network_image_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_network_image_platform_interface_ce
 description: Platform interface for CachedNetworkImage (Community Edition)
-version: 5.1.0
+version: 5.2.0
 homepage: https://github.com/Erengun/flutter_cached_network_image_ce
 repository: https://github.com/Erengun/flutter_cached_network_image_ce/tree/develop/cached_network_image_platform_interface
 topics:

--- a/cached_network_image_platform_interface/test/cached_network_image_platform_interface_ce_test.dart
+++ b/cached_network_image_platform_interface/test/cached_network_image_platform_interface_ce_test.dart
@@ -251,6 +251,66 @@ void main() {
       expect(cacheLogger, same(custom));
     });
   });
+
+  group('ConnectionParameters', () {
+    test('can be created with no arguments', () {
+      const cp = ConnectionParameters();
+      expect(cp.connectionTimeout, isNull);
+      expect(cp.requestTimeout, isNull);
+    });
+
+    test('stores connectionTimeout', () {
+      const cp = ConnectionParameters(
+        connectionTimeout: Duration(seconds: 10),
+      );
+      expect(cp.connectionTimeout, const Duration(seconds: 10));
+      expect(cp.requestTimeout, isNull);
+    });
+
+    test('stores requestTimeout', () {
+      const cp = ConnectionParameters(
+        requestTimeout: Duration(seconds: 30),
+      );
+      expect(cp.connectionTimeout, isNull);
+      expect(cp.requestTimeout, const Duration(seconds: 30));
+    });
+
+    test('stores both timeouts', () {
+      const cp = ConnectionParameters(
+        connectionTimeout: Duration(seconds: 5),
+        requestTimeout: Duration(seconds: 15),
+      );
+      expect(cp.connectionTimeout, const Duration(seconds: 5));
+      expect(cp.requestTimeout, const Duration(seconds: 15));
+    });
+
+    test('equality works', () {
+      const a = ConnectionParameters(
+        connectionTimeout: Duration(seconds: 10),
+        requestTimeout: Duration(seconds: 30),
+      );
+      const b = ConnectionParameters(
+        connectionTimeout: Duration(seconds: 10),
+        requestTimeout: Duration(seconds: 30),
+      );
+      const c = ConnectionParameters(
+        connectionTimeout: Duration(seconds: 5),
+        requestTimeout: Duration(seconds: 30),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString is informative', () {
+      const cp = ConnectionParameters(
+        connectionTimeout: Duration(seconds: 10),
+        requestTimeout: Duration(seconds: 30),
+      );
+      expect(cp.toString(), contains('connectionTimeout'));
+      expect(cp.toString(), contains('requestTimeout'));
+    });
+  });
 }
 
 Future<ui.Codec> decoder(

--- a/cached_network_image_platform_interface/test/cached_network_image_platform_interface_ce_test.dart
+++ b/cached_network_image_platform_interface/test/cached_network_image_platform_interface_ce_test.dart
@@ -254,48 +254,66 @@ void main() {
 
   group('ConnectionParameters', () {
     test('can be created with no arguments', () {
-      const cp = ConnectionParameters();
+      final cp = ConnectionParameters();
       expect(cp.connectionTimeout, isNull);
       expect(cp.requestTimeout, isNull);
     });
 
     test('stores connectionTimeout', () {
-      const cp = ConnectionParameters(
-        connectionTimeout: Duration(seconds: 10),
+      final cp = ConnectionParameters(
+        connectionTimeout: const Duration(seconds: 10),
       );
       expect(cp.connectionTimeout, const Duration(seconds: 10));
       expect(cp.requestTimeout, isNull);
     });
 
     test('stores requestTimeout', () {
-      const cp = ConnectionParameters(
-        requestTimeout: Duration(seconds: 30),
+      final cp = ConnectionParameters(
+        requestTimeout: const Duration(seconds: 30),
       );
       expect(cp.connectionTimeout, isNull);
       expect(cp.requestTimeout, const Duration(seconds: 30));
     });
 
     test('stores both timeouts', () {
-      const cp = ConnectionParameters(
-        connectionTimeout: Duration(seconds: 5),
-        requestTimeout: Duration(seconds: 15),
+      final cp = ConnectionParameters(
+        connectionTimeout: const Duration(seconds: 5),
+        requestTimeout: const Duration(seconds: 15),
       );
       expect(cp.connectionTimeout, const Duration(seconds: 5));
       expect(cp.requestTimeout, const Duration(seconds: 15));
     });
 
+    test('throws when connectionTimeout is negative', () {
+      expect(
+        () => ConnectionParameters(
+          connectionTimeout: const Duration(seconds: -1),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when requestTimeout is negative', () {
+      expect(
+        () => ConnectionParameters(
+          requestTimeout: const Duration(seconds: -1),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test('equality works', () {
-      const a = ConnectionParameters(
-        connectionTimeout: Duration(seconds: 10),
-        requestTimeout: Duration(seconds: 30),
+      final a = ConnectionParameters(
+        connectionTimeout: const Duration(seconds: 10),
+        requestTimeout: const Duration(seconds: 30),
       );
-      const b = ConnectionParameters(
-        connectionTimeout: Duration(seconds: 10),
-        requestTimeout: Duration(seconds: 30),
+      final b = ConnectionParameters(
+        connectionTimeout: const Duration(seconds: 10),
+        requestTimeout: const Duration(seconds: 30),
       );
-      const c = ConnectionParameters(
-        connectionTimeout: Duration(seconds: 5),
-        requestTimeout: Duration(seconds: 30),
+      final c = ConnectionParameters(
+        connectionTimeout: const Duration(seconds: 5),
+        requestTimeout: const Duration(seconds: 30),
       );
       expect(a, equals(b));
       expect(a.hashCode, b.hashCode);
@@ -303,9 +321,9 @@ void main() {
     });
 
     test('toString is informative', () {
-      const cp = ConnectionParameters(
-        connectionTimeout: Duration(seconds: 10),
-        requestTimeout: Duration(seconds: 30),
+      final cp = ConnectionParameters(
+        connectionTimeout: const Duration(seconds: 10),
+        requestTimeout: const Duration(seconds: 30),
       );
       expect(cp.toString(), contains('connectionTimeout'));
       expect(cp.toString(), contains('requestTimeout'));

--- a/commit_style.md
+++ b/commit_style.md
@@ -1,0 +1,146 @@
+The Conventional Commits specification is a lightweight convention on top of commit messages.
+It provides an easy set of rules for creating an explicit commit history;
+which makes it easier to write automated tools on top of.
+This convention dovetails with [SemVer](http://semver.org),
+by describing the features, fixes, and breaking changes made in commit messages.
+
+The commit message should be structured as follows:
+
+---
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer]
+```
+---
+
+<br />
+The commit contains the following structural elements, to communicate intent to the
+consumers of your library:
+
+1. **fix:** a commit of the _type_ `fix` patches a bug in your codebase (this correlates with [`PATCH`](http://semver.org/#summary) in semantic versioning).
+1. **feat:** a commit of the _type_ `feat` introduces a new feature to the codebase (this correlates with [`MINOR`](http://semver.org/#summary) in semantic versioning).
+1. **BREAKING CHANGE:** a commit that has the text `BREAKING CHANGE:` at the beginning of its optional body or footer section introduces a breaking API change (correlating with [`MAJOR`](http://semver.org/#summary) in semantic versioning).
+A BREAKING CHANGE can be part of commits of any _type_.
+1. Others: commit _types_ other than `fix:` and `feat:` are allowed, for example [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) (based on the [Angular convention](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit)) recommends `chore:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others.
+
+We also recommend `improvement` for commits that improve a current implementation without adding a new feature or fixing a bug.
+Notice these types are not mandated by the conventional commits specification, and have no implicit effect in semantic versioning (unless they include a BREAKING CHANGE).
+<br />
+A scope may be provided to a commit's type, to provide additional contextual information and is contained within parenthesis, e.g., `feat(parser): add ability to parse arrays`.
+
+## Examples
+
+### Commit message with description and breaking change in body
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Commit message with optional `!` to draw attention to breaking change
+```
+chore!: drop Node 6 from testing matrix
+
+BREAKING CHANGE: dropping Node 6 which hits end of life in April
+```
+
+### Commit message with no body
+```
+docs: correct spelling of CHANGELOG
+```
+
+### Commit message with scope
+```
+feat(lang): add polish language
+```
+
+### Commit message for a fix using an (optional) issue number.
+```
+fix: correct minor typos in code
+
+see the issue for details on the typos fixed
+
+closes issue #12
+```
+
+## Specification
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed
+  by an OPTIONAL scope, and a REQUIRED terminal colon and space.
+1. The type `feat` MUST be used when a commit adds a new feature to your application or library.
+1. The type `fix` MUST be used when a commit represents a bug fix for your application.
+1. A scope MAY be provided after a type. A scope MUST consist of a noun describing a
+  section of the codebase surrounded by parenthesis, e.g., `fix(parser):`
+1. A description MUST immediately follow the space after the type/scope prefix.
+The description is a short summary of the code changes, e.g., _fix: array parsing issue when multiple spaces were contained in string._
+1. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+1. A footer of one or more lines MAY be provided one blank line after the body. The footer MUST contain meta-information
+about the commit, e.g., related pull-requests, reviewers, breaking changes, with one piece of meta-information
+per-line.
+1. Breaking changes MUST be indicated at the very beginning of the body section, or at the beginning of a line in the footer section. A breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon and a space.
+1. A description MUST be provided after the `BREAKING CHANGE: `, describing what has changed about the API, e.g., _BREAKING CHANGE: environment variables now take precedence over config files._
+1. Types other than `feat` and `fix` MAY be used in your commit messages.
+1. The units of information that make up conventional commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+1. A `!` MAY be appended prior to the `:` in the type/scope prefix, to further draw attention to breaking changes. `BREAKING CHANGE: description` MUST also be included in the body
+or footer, along with the `!` in the prefix.
+
+## Why Use Conventional Commits
+
+* Automatically generating CHANGELOGs.
+* Automatically determining a semantic version bump (based on the types of commits landed).
+* Communicating the nature of changes to teammates, the public, and other stakeholders.
+* Triggering build and publish processes.
+* Making it easier for people to contribute to your projects, by allowing them to explore
+  a more structured commit history.
+
+## FAQ
+
+### How should I deal with commit messages in the initial development phase?
+
+We recommend that you proceed as if you've already released the product. Typically *somebody*, even if it's your fellow software developers, is using your software. They'll want to know what's fixed, what breaks etc.
+
+### Are the types in the commit title uppercase or lowercase?
+
+Any casing may be used, but it's best to be consistent.
+
+### What do I do if the commit conforms to more than one of the commit types?
+
+Go back and make multiple commits whenever possible. Part of the benefit of Conventional Commits is its ability to drive us to make more organized commits and PRs.
+
+### Doesn’t this discourage rapid development and fast iteration?
+
+It discourages moving fast in a disorganized way. It helps you be able to move fast long term across multiple projects with varied contributors.
+
+### Might Conventional Commits lead developers to limit the type of commits they make because they'll be thinking in the types provided?
+
+Conventional Commits encourages us to make more of certain types of commits such as fixes. Other than that, the flexibility of Conventional Commits allows your team to come up with their own types and change those types over time.
+
+### How does this relate to SemVer?
+
+`fix` type commits should be translated to `PATCH` releases. `feat` type commits should be translated to `MINOR` releases. Commits with `BREAKING CHANGE` in the commits, regardless of type, should be translated to `MAJOR` releases.
+
+### How should I version my extensions to the Conventional Commits Specification, e.g. `@jameswomack/conventional-commit-spec`?
+
+We recommend using SemVer to release your own extensions to this specification (and
+encourage you to make these extensions!)
+
+### What do I do if I accidentally use the wrong commit type?
+
+#### When you used a type that's of the spec but not the correct type, e.g. `fix` instead of `feat`
+
+Prior to merging or releasing the mistake, we recommend using `git rebase -i` to edit the commit history. After release, the cleanup will be different according to what tools and processes you use.
+
+#### When you used a type *not* of the spec, e.g. `feet` instead of `feat`
+
+In a worst case scenario, it's not the end of the world if a commit lands that does not meet the conventional commit specification. It simply means that commit will be missed by tools that are based on the spec.
+
+### Do all my contributors need to use the conventional commit specification?
+
+No! If you use a squash based workflow on Git lead maintainers can clean up the commit messages as they're merged—adding no workload to casual committers.
+A common workflow for this is to have your git system automatically squash commits from a pull request and present a form for the lead maintainer to enter the proper git commit message for the merge.


### PR DESCRIPTION
## Description

Introduce `ConnectionParameters` to manage HTTP connection and request timeouts in `DefaultCacheManager`. This enhancement allows for better control over network requests, ensuring that timeouts can be set while maintaining existing behavior when omitted.

## Related Issues

Resolves https://github.com/Erengun/flutter_cached_network_image_ce/issues/8
https://github.com/Baseflow/flutter_cached_network_image/issues/465
https://github.com/Baseflow/flutter_cached_network_image/issues/1001

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional HTTP timeout configuration for image downloads via new ConnectionParameters (separate connection and request timeouts).

* **Documentation**
  * Network Timeouts guide with examples and Flutter Web notes (timeouts apply when using HTTP fetch).
  * SVG guidance: SVG bytes follow unsupported-image path with recommended unsupportedImageBuilder.
  * Added Conventional Commits reference.

* **Tests**
  * Comprehensive tests covering timeout behaviors and client cleanup.

* **Chores**
  * Package/readme and version updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->