### PR TITLE
Fix Hive box corruption recovery

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.6.2] - 2026-03-04
+
+* **Fix:** Handle Hive box corruption gracefully during cache initialization.
+  * When `openBox` encounters a corrupted box with unknown typeIds (e.g., from removed adapters), catch `HiveError`, safely delete the box, and retry initialization.
+  * Cleans up orphaned cache files after box recovery to prevent stale data.
+  * Regression tests added for box corruption recovery on both IO and web platforms.
+  * Issue #12: Fixes production crash "HiveError: Cannot read, unknown typeId" reported via Firebase Crashlytics.
+
 ## [4.6.1] - 2026-03-04
 
 * **Fix:** Re-export `ConnectionParameters` from the main `cached_network_image_ce` barrel file so it is accessible without a separate `cached_network_image_platform_interface_ce` import.

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -122,10 +122,64 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     // Open the box with an explicit path on the private Hive instance.
     // This avoids calling Hive.init() which would conflict with the
     // host application's own Hive initialization.
-    _cacheBox = await _hive.openBox<Map>(_kBoxName, path: hivePath);
+    try {
+      _cacheBox = await _hive.openBox<Map>(_kBoxName, path: hivePath);
+    } on HiveError catch (e) {
+      // Box corruption (e.g. "Cannot read, unknown typeId: 121").
+      // Since this is a cache, we can safely delete the corrupted box
+      // and start fresh. Cached images will simply be re-downloaded.
+      cacheLogger.log(
+        'CacheManager: Hive box corrupted, resetting cache: $e',
+        CacheManagerLogLevel.warning,
+      );
+      await _safeDeleteBox(_kBoxName, hivePath);
+      _cacheBox = await _hive.openBox<Map>(_kBoxName, path: hivePath);
+
+      // Also remove cached files since their metadata is gone.
+      await _deleteCacheFiles();
+    }
 
     // Run cleanup in background
     unawaited(_cleanupOldFiles());
+  }
+
+  /// Attempts to delete a Hive box from disk, tolerating missing files.
+  ///
+  /// [HiveImpl.deleteBoxFromDisk] can throw [PathNotFoundException] when
+  /// auxiliary files (e.g. `.lock`) are already gone. In that case we
+  /// fall back to manually deleting the `.hive` file.
+  Future<void> _safeDeleteBox(String boxName, String boxPath) async {
+    try {
+      await _hive.deleteBoxFromDisk(boxName, path: boxPath);
+    } on Object catch (_) {
+      // Fallback: delete the .hive file directly.
+      final boxFile = io.File(path.join(boxPath, '$boxName.hive'));
+      if (await boxFile.exists()) {
+        await boxFile.delete();
+      }
+    }
+  }
+
+  /// Deletes all cached image files in the cache directory.
+  ///
+  /// Called after a corruption recovery to remove orphaned files whose
+  /// metadata has been lost.
+  Future<void> _deleteCacheFiles() async {
+    try {
+      final cacheDir = io.Directory(_cacheDir!);
+      if (await cacheDir.exists()) {
+        await for (final entity in cacheDir.list()) {
+          if (entity is io.File) {
+            await entity.delete();
+          }
+        }
+      }
+    } on Object catch (e) {
+      cacheLogger.log(
+        'CacheManager: Error cleaning orphaned cache files: $e',
+        CacheManagerLogLevel.warning,
+      );
+    }
   }
 
   String _cacheFilePath(String relativePath) {

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -94,11 +94,38 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     // On web, Hive uses IndexedDB — no path argument needed.
     // We use a private HiveImpl instance to avoid conflicts with the
     // host app's own Hive boxes.
-    _metaBox = await _hive.openBox<Map>(_kMetaBoxName);
-    _dataBox = await _hive.openLazyBox<List<int>>(_kDataBoxName);
+    try {
+      _metaBox = await _hive.openBox<Map>(_kMetaBoxName);
+      _dataBox = await _hive.openLazyBox<List<int>>(_kDataBoxName);
+    } on HiveError catch (e) {
+      // Box corruption (e.g. "Cannot read, unknown typeId: 121").
+      // Since this is a cache, we can safely delete the corrupted boxes
+      // and start fresh. Cached images will simply be re-downloaded.
+      cacheLogger.log(
+        'CacheManager: Hive box corrupted, resetting cache: $e',
+        CacheManagerLogLevel.warning,
+      );
+      await _safeDeleteBox(_kMetaBoxName);
+      await _safeDeleteBox(_kDataBoxName);
+      _metaBox = await _hive.openBox<Map>(_kMetaBoxName);
+      _dataBox = await _hive.openLazyBox<List<int>>(_kDataBoxName);
+    }
 
     // Run cleanup in background.
     unawaited(_cleanupOldEntries());
+  }
+
+  /// Attempts to delete a Hive box from disk, tolerating missing files.
+  ///
+  /// [HiveImpl.deleteBoxFromDisk] can throw [PathNotFoundException] when
+  /// auxiliary files (e.g. `.lock`) are already gone. We swallow the error
+  /// since we're already in a corruption-recovery path.
+  Future<void> _safeDeleteBox(String boxName) async {
+    try {
+      await _hive.deleteBoxFromDisk(boxName);
+    } on Object catch (_) {
+      // Best-effort: if the box files are already gone, that's fine.
+    }
   }
 
   /// Gets the file extension from a URL.

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.6.1
+version: 4.6.2
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -6,8 +6,32 @@ import 'package:cached_network_image_platform_interface_ce/cached_network_image_
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
+// ignore: implementation_imports
+import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
+
+/// A custom object that forces Hive to write a user-defined typeId into
+/// the box file. When the box is later opened without this adapter
+/// registered, Hive throws [HiveError] with "unknown typeId".
+class _CorruptPayload {
+  _CorruptPayload(this.data);
+  final String data;
+}
+
+/// Adapter with typeId 121 — the exact id reported in issue #12.
+class _CorruptPayloadAdapter extends TypeAdapter<_CorruptPayload> {
+  @override
+  final int typeId = 121;
+
+  @override
+  _CorruptPayload read(BinaryReader reader) =>
+      _CorruptPayload(reader.readString());
+
+  @override
+  void write(BinaryWriter writer, _CorruptPayload obj) =>
+      writer.writeString(obj.data);
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -729,11 +753,15 @@ void main() {
   });
 
   // ---- Issue 4: Hive box corruption recovery (#12) ----
+  //
+  // Reproduces the exact crash: "HiveError: Cannot read, unknown typeId: 121".
+  // A custom TypeAdapter writes an entry with typeId 121 into the cache box.
+  // When the box is re-opened without that adapter registered, openBox throws
+  // HiveError. The fix should catch this and delete + recreate the box.
 
   group('Regression: Hive box corruption recovery', () {
     test('recovers from corrupted Hive box on init', () async {
-      final customDir =
-          io.Directory.systemTemp.createTempSync('corrupt_hive_');
+      final customDir = io.Directory.systemTemp.createTempSync('corrupt_hive_');
       addTearDown(() {
         try {
           customDir.deleteSync(recursive: true);
@@ -755,29 +783,19 @@ void main() {
       expect(cached1, isNotNull);
       await manager1.dispose();
 
-      // Now corrupt the Hive box file by writing garbage data.
-      final hiveDir =
-          io.Directory('${customDir.path}/cached_network_image_ce/hive');
-      expect(hiveDir.existsSync(), isTrue);
-
-      final hiveFiles = hiveDir
-          .listSync()
-          .whereType<io.File>()
-          .where((f) => f.path.endsWith('.hive'))
-          .toList();
-      expect(hiveFiles, isNotEmpty, reason: 'Should have .hive box file');
-
-      for (final hiveFile in hiveFiles) {
-        // Write corrupted binary data that includes an invalid typeId.
-        await hiveFile.writeAsBytes([
-          0x48, 0x49, 0x56, 0x45, // HIVE magic
-          0x01, // version
-          0x00, 0x00, // unused
-          0xFF, 0xFF, 0xFF, 0xFF, // corrupted frame
-          0x79, // typeId 121 (0x79) - the exact error from issue #12
-          0x00, 0x00, 0x00, 0x00,
-        ]);
-      }
+      // Poison the same Hive box by writing an entry with a custom
+      // TypeAdapter (typeId 121). This simulates cross-isolate corruption
+      // or leftover data from a removed adapter.
+      final hivePath = '${customDir.path}/cached_network_image_ce/hive';
+      final poisonHive = HiveImpl();
+      poisonHive.registerAdapter(_CorruptPayloadAdapter());
+      final poisonBox = await poisonHive.openBox(
+        'cached_network_image_cache',
+        path: hivePath,
+      );
+      await poisonBox.put('__corrupt__', _CorruptPayload('bad'));
+      await poisonBox.close();
+      await poisonHive.close();
 
       // Re-create the manager — it should recover from corruption.
       final manager2 = DefaultCacheManager(
@@ -815,7 +833,7 @@ void main() {
         } on Object catch (_) {}
       });
 
-      // Create a valid cache first, then corrupt it.
+      // Create a valid cache first, then poison the box.
       final manager1 = DefaultCacheManager(
         cacheDirectoryProvider: () async => customDir,
       );
@@ -826,18 +844,17 @@ void main() {
       );
       await manager1.dispose();
 
-      // Corrupt the Hive box.
-      final hiveDir =
-          io.Directory('${customDir.path}/cached_network_image_ce/hive');
-      for (final hiveFile in hiveDir
-          .listSync()
-          .whereType<io.File>()
-          .where((f) => f.path.endsWith('.hive'))) {
-        await hiveFile.writeAsBytes([
-          0x48, 0x49, 0x56, 0x45, 0x01, 0x00, 0x00,
-          0xFF, 0xFF, 0xFF, 0xFF, 0x79, 0x00, 0x00, 0x00, 0x00,
-        ]);
-      }
+      // Poison the box with an unregistered typeId entry.
+      final hivePath = '${customDir.path}/cached_network_image_ce/hive';
+      final poisonHive = HiveImpl();
+      poisonHive.registerAdapter(_CorruptPayloadAdapter());
+      final poisonBox = await poisonHive.openBox(
+        'cached_network_image_cache',
+        path: hivePath,
+      );
+      await poisonBox.put('__corrupt__', _CorruptPayload('bad'));
+      await poisonBox.close();
+      await poisonHive.close();
 
       // Create a new manager and fire concurrent operations.
       final manager2 = DefaultCacheManager(

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -728,6 +728,146 @@ void main() {
     });
   });
 
+  // ---- Issue 4: Hive box corruption recovery (#12) ----
+
+  group('Regression: Hive box corruption recovery', () {
+    test('recovers from corrupted Hive box on init', () async {
+      final customDir =
+          io.Directory.systemTemp.createTempSync('corrupt_hive_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      // First, create a valid cache entry so files exist on disk.
+      final manager1 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+      await manager1.putFile(
+        'https://example.com/corrupt-test.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+      final cached1 = await manager1.getFileFromCache(
+        'https://example.com/corrupt-test.bin',
+      );
+      expect(cached1, isNotNull);
+      await manager1.dispose();
+
+      // Now corrupt the Hive box file by writing garbage data.
+      final hiveDir =
+          io.Directory('${customDir.path}/cached_network_image_ce/hive');
+      expect(hiveDir.existsSync(), isTrue);
+
+      final hiveFiles = hiveDir
+          .listSync()
+          .whereType<io.File>()
+          .where((f) => f.path.endsWith('.hive'))
+          .toList();
+      expect(hiveFiles, isNotEmpty, reason: 'Should have .hive box file');
+
+      for (final hiveFile in hiveFiles) {
+        // Write corrupted binary data that includes an invalid typeId.
+        await hiveFile.writeAsBytes([
+          0x48, 0x49, 0x56, 0x45, // HIVE magic
+          0x01, // version
+          0x00, 0x00, // unused
+          0xFF, 0xFF, 0xFF, 0xFF, // corrupted frame
+          0x79, // typeId 121 (0x79) - the exact error from issue #12
+          0x00, 0x00, 0x00, 0x00,
+        ]);
+      }
+
+      // Re-create the manager — it should recover from corruption.
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+
+      // Old entry is gone (box was wiped), but no crash.
+      final cached2 = await manager2.getFileFromCache(
+        'https://example.com/corrupt-test.bin',
+      );
+      expect(cached2, isNull);
+
+      // New entries should work fine.
+      await manager2.putFile(
+        'https://example.com/after-recovery.bin',
+        [4, 5, 6],
+        fileExtension: 'bin',
+      );
+      final cached3 = await manager2.getFileFromCache(
+        'https://example.com/after-recovery.bin',
+      );
+      expect(cached3, isNotNull);
+      expect(cached3!.originalUrl, 'https://example.com/after-recovery.bin');
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+
+    test('concurrent callers all succeed after corruption recovery', () async {
+      final customDir =
+          io.Directory.systemTemp.createTempSync('corrupt_concurrent_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      // Create a valid cache first, then corrupt it.
+      final manager1 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+      await manager1.putFile(
+        'https://example.com/pre-corruption.bin',
+        [1],
+        fileExtension: 'bin',
+      );
+      await manager1.dispose();
+
+      // Corrupt the Hive box.
+      final hiveDir =
+          io.Directory('${customDir.path}/cached_network_image_ce/hive');
+      for (final hiveFile in hiveDir
+          .listSync()
+          .whereType<io.File>()
+          .where((f) => f.path.endsWith('.hive'))) {
+        await hiveFile.writeAsBytes([
+          0x48, 0x49, 0x56, 0x45, 0x01, 0x00, 0x00,
+          0xFF, 0xFF, 0xFF, 0xFF, 0x79, 0x00, 0x00, 0x00, 0x00,
+        ]);
+      }
+
+      // Create a new manager and fire concurrent operations.
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+
+      final futures = List.generate(
+        10,
+        (i) => manager2.putFile(
+          'https://example.com/concurrent-$i.bin',
+          List.filled(i + 1, i),
+          fileExtension: 'bin',
+        ),
+      );
+
+      // All should complete without throwing.
+      await Future.wait(futures);
+
+      for (var i = 0; i < 10; i++) {
+        final cached = await manager2.getFileFromCache(
+          'https://example.com/concurrent-$i.bin',
+        );
+        expect(cached, isNotNull, reason: 'Entry $i should exist');
+      }
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+  });
+
   // ---- putFile / getFileFromCache / removeFile / emptyCache ----
 
   group('DefaultCacheManager cache operations', () {

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -626,6 +626,131 @@ void main() {
   });
 
   // =====================================================================
+  // Hive box corruption recovery (#12)
+  // =====================================================================
+
+  group('WebCacheManager corruption recovery', () {
+    test('recovers from corrupted Hive meta box on init', () async {
+      // First, create valid entries.
+      final manager1 = DefaultCacheManager(hiveInstance: testHive);
+      await manager1.putFile(
+        'https://example.com/corrupt-web.png',
+        [1, 2, 3],
+        fileExtension: 'png',
+      );
+      final cached1 = await manager1.getFileFromCache(
+        'https://example.com/corrupt-web.png',
+      );
+      expect(cached1, isNotNull);
+      await manager1.dispose();
+
+      // Corrupt the meta box file by writing garbage data with an invalid
+      // typeId, simulating the exact error from issue #12.
+      final hiveFiles = io.Directory(hiveTempDir.path)
+          .listSync()
+          .whereType<io.File>()
+          .where((f) =>
+              f.path.contains('cached_network_image_cache') &&
+              f.path.endsWith('.hive'))
+          .toList();
+      expect(hiveFiles, isNotEmpty, reason: 'Should have .hive box file');
+
+      for (final hiveFile in hiveFiles) {
+        await hiveFile.writeAsBytes([
+          0x48, 0x49, 0x56, 0x45, // HIVE magic
+          0x01, // version
+          0x00, 0x00, // unused
+          0xFF, 0xFF, 0xFF, 0xFF, // corrupted frame
+          0x79, // typeId 121 (0x79) - the error from issue #12
+          0x00, 0x00, 0x00, 0x00,
+        ]);
+      }
+
+      // Re-create manager with a fresh Hive instance (simulating app restart).
+      final freshHive = HiveImpl();
+      freshHive.init(hiveTempDir.path);
+      addTearDown(() => freshHive.close());
+
+      final manager2 = DefaultCacheManager(hiveInstance: freshHive);
+
+      // Old entry is gone (box was wiped), but no crash.
+      final cached2 = await manager2.getFileFromCache(
+        'https://example.com/corrupt-web.png',
+      );
+      expect(cached2, isNull);
+
+      // New entries should work fine.
+      await manager2.putFile(
+        'https://example.com/after-web-recovery.png',
+        [4, 5, 6],
+        fileExtension: 'png',
+      );
+      final cached3 = await manager2.getFileFromCache(
+        'https://example.com/after-web-recovery.png',
+      );
+      expect(cached3, isNotNull);
+      expect(
+        cached3!.originalUrl,
+        'https://example.com/after-web-recovery.png',
+      );
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+
+    test('concurrent callers all succeed after corruption recovery', () async {
+      // Create valid data, then corrupt it.
+      final manager1 = DefaultCacheManager(hiveInstance: testHive);
+      await manager1.putFile(
+        'https://example.com/pre-corrupt.png',
+        [1],
+        fileExtension: 'png',
+      );
+      await manager1.dispose();
+
+      // Corrupt the meta box.
+      for (final hiveFile in io.Directory(hiveTempDir.path)
+          .listSync()
+          .whereType<io.File>()
+          .where((f) =>
+              f.path.contains('cached_network_image_cache') &&
+              f.path.endsWith('.hive'))) {
+        await hiveFile.writeAsBytes([
+          0x48, 0x49, 0x56, 0x45, 0x01, 0x00, 0x00,
+          0xFF, 0xFF, 0xFF, 0xFF, 0x79, 0x00, 0x00, 0x00, 0x00,
+        ]);
+      }
+
+      final freshHive = HiveImpl();
+      freshHive.init(hiveTempDir.path);
+      addTearDown(() => freshHive.close());
+
+      final manager2 = DefaultCacheManager(hiveInstance: freshHive);
+
+      // Fire concurrent operations — all should complete without throwing.
+      final futures = List.generate(
+        10,
+        (i) => manager2.putFile(
+          'https://example.com/web-concurrent-recovery-$i.png',
+          List.filled(i + 1, i),
+          fileExtension: 'png',
+        ),
+      );
+      await Future.wait(futures);
+
+      for (var i = 0; i < 10; i++) {
+        final cached = await manager2.getFileFromCache(
+          'https://example.com/web-concurrent-recovery-$i.png',
+        );
+        expect(cached, isNotNull, reason: 'Entry $i should exist');
+      }
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+  });
+
+  // =====================================================================
   // Dispose / lifecycle
   // =====================================================================
 

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -10,6 +10,28 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 
+/// A custom object that forces Hive to write a user-defined typeId into
+/// the box file. When the box is later opened without this adapter
+/// registered, Hive throws [HiveError] with "unknown typeId".
+class _CorruptPayload {
+  _CorruptPayload(this.data);
+  final String data;
+}
+
+/// Adapter with typeId 121 — the exact id reported in issue #12.
+class _CorruptPayloadAdapter extends TypeAdapter<_CorruptPayload> {
+  @override
+  final int typeId = 121;
+
+  @override
+  _CorruptPayload read(BinaryReader reader) =>
+      _CorruptPayload(reader.readString());
+
+  @override
+  void write(BinaryWriter writer, _CorruptPayload obj) =>
+      writer.writeString(obj.data);
+}
+
 void main() {
   late io.Directory hiveTempDir;
   late HiveInterface testHive;
@@ -644,27 +666,16 @@ void main() {
       expect(cached1, isNotNull);
       await manager1.dispose();
 
-      // Corrupt the meta box file by writing garbage data with an invalid
-      // typeId, simulating the exact error from issue #12.
-      final hiveFiles = io.Directory(hiveTempDir.path)
-          .listSync()
-          .whereType<io.File>()
-          .where((f) =>
-              f.path.contains('cached_network_image_cache') &&
-              f.path.endsWith('.hive'))
-          .toList();
-      expect(hiveFiles, isNotEmpty, reason: 'Should have .hive box file');
-
-      for (final hiveFile in hiveFiles) {
-        await hiveFile.writeAsBytes([
-          0x48, 0x49, 0x56, 0x45, // HIVE magic
-          0x01, // version
-          0x00, 0x00, // unused
-          0xFF, 0xFF, 0xFF, 0xFF, // corrupted frame
-          0x79, // typeId 121 (0x79) - the error from issue #12
-          0x00, 0x00, 0x00, 0x00,
-        ]);
-      }
+      // Poison the meta box by writing an entry with a custom TypeAdapter
+      // (typeId 121). When the box is reopened without the adapter,
+      // Hive throws HiveError with "unknown typeId".
+      final poisonHive = HiveImpl();
+      poisonHive.init(hiveTempDir.path);
+      poisonHive.registerAdapter(_CorruptPayloadAdapter());
+      final poisonBox = await poisonHive.openBox('cached_network_image_cache');
+      await poisonBox.put('__corrupt__', _CorruptPayload('bad'));
+      await poisonBox.close();
+      await poisonHive.close();
 
       // Re-create manager with a fresh Hive instance (simulating app restart).
       final freshHive = HiveImpl();
@@ -699,7 +710,7 @@ void main() {
     });
 
     test('concurrent callers all succeed after corruption recovery', () async {
-      // Create valid data, then corrupt it.
+      // Create valid data, then poison the box.
       final manager1 = DefaultCacheManager(hiveInstance: testHive);
       await manager1.putFile(
         'https://example.com/pre-corrupt.png',
@@ -708,18 +719,14 @@ void main() {
       );
       await manager1.dispose();
 
-      // Corrupt the meta box.
-      for (final hiveFile in io.Directory(hiveTempDir.path)
-          .listSync()
-          .whereType<io.File>()
-          .where((f) =>
-              f.path.contains('cached_network_image_cache') &&
-              f.path.endsWith('.hive'))) {
-        await hiveFile.writeAsBytes([
-          0x48, 0x49, 0x56, 0x45, 0x01, 0x00, 0x00,
-          0xFF, 0xFF, 0xFF, 0xFF, 0x79, 0x00, 0x00, 0x00, 0x00,
-        ]);
-      }
+      // Poison the meta box with an unregistered typeId entry.
+      final poisonHive = HiveImpl();
+      poisonHive.init(hiveTempDir.path);
+      poisonHive.registerAdapter(_CorruptPayloadAdapter());
+      final poisonBox = await poisonHive.openBox('cached_network_image_cache');
+      await poisonBox.put('__corrupt__', _CorruptPayload('bad'));
+      await poisonBox.close();
+      await poisonHive.close();
 
       final freshHive = HiveImpl();
       freshHive.init(hiveTempDir.path);


### PR DESCRIPTION
## Description

Hive box corruption (from cross-isolate usage, removed adapters, or disk issues) causes HiveError during openBox since non-lazy boxes read all frames into memory on open.

Implement robust recovery from Hive box corruption during cache initialization. When encountering a corrupted box with unknown typeIds, the system now logs a warning, deletes the corrupted boxes, and reopens fresh boxes to maintain cache integrity. This change includes regression tests to ensure the cache manager can recover from such corruption scenarios on both IO and web platforms.

## Related Issues

*Fixes #12*

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes caused by cache corruption with automatic recovery and cache reset functionality
  * Automatic cleanup of orphaned cache files during the recovery process to ensure system consistency

* **Tests**
  * Added regression tests to validate cache corruption recovery across different platforms and concurrent operation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->