### PR TITLE
Enforce custom headers usage with HttpGet on Web

### DIFF
--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -144,6 +144,22 @@ On Flutter Web, timeout settings apply when using
 `ImageRenderMethodForWeb.HttpGet`. The `HtmlImage` render method uses the
 browser image pipeline and bypasses the cache manager HTTP path.
 
+**Web Platform Headers Support:** Custom headers (like `Authorization`) are
+**only supported with `ImageRenderMethodForWeb.HttpGet`**. The default
+`HtmlImage` render method does not support custom headers. If you need to
+send headers to authenticate image requests on Web, you must explicitly set:
+
+```dart
+CachedNetworkImage(
+  imageUrl: 'https://api.example.com/image.jpg',
+  httpHeaders: {'Authorization': 'Bearer token'},
+  imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
+),
+```
+
+Note: Using `HttpGet` on Web disables the browser's default image caching
+mechanisms, so images are cached via the `cache_manager` instead.
+
 ### SVG Support
 
 Flutter's built-in image codec doesn't support SVG. When `CachedNetworkImage`

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -201,7 +201,13 @@ class CachedNetworkImage extends StatefulWidget {
   /// scope.
   final bool matchTextDirection;
 
-  /// Optional headers for the http request of the image url
+  /// Optional headers for the http request of the image url.
+  ///
+  /// **Note on Flutter Web:** Headers are only supported when using
+  /// [ImageRenderMethodForWeb.HttpGet] render method. The default
+  /// [ImageRenderMethodForWeb.HtmlImage] does not support custom headers.
+  /// If you provide headers on Web, you must also set
+  /// `imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet`.
   final Map<String, String>? httpHeaders;
 
   /// When set to true it will animate from the old image to the new image

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -52,7 +52,13 @@ class CachedNetworkImageProvider
   /// to avoid this issue.
   final ErrorListener? errorListener;
 
-  /// Set headers for the image provider, for example for authentication
+  /// Set headers for the image provider, for example for authentication.
+  ///
+  /// **Note on Flutter Web:** Headers are only supported when using
+  /// [ImageRenderMethodForWeb.HttpGet] render method. The default
+  /// [ImageRenderMethodForWeb.HtmlImage] does not support custom headers.
+  /// If you provide headers on Web, you must also set
+  /// `imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet`.
   final Map<String, String>? headers;
 
   /// Maximum height of the loaded image. If not null and using an

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -115,8 +115,8 @@ class ImageLoader implements platform.ImageLoader {
         imageRenderMethodForWeb,
         'imageRenderMethodForWeb',
         'Headers are only supported with ImageRenderMethodForWeb.HttpGet. '
-        'HtmlImage does not support custom headers. '
-        'Please use ImageRenderMethodForWeb.HttpGet when providing headers.',
+            'HtmlImage does not support custom headers. '
+            'Please use ImageRenderMethodForWeb.HttpGet when providing headers.',
       );
     }
 

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -108,6 +108,14 @@ class ImageLoader implements platform.ImageLoader {
     platform.ImageRenderMethodForWeb imageRenderMethodForWeb,
     VoidCallback evictImage,
   ) {
+    // Ensure HttpGet is used when headers are provided
+    assert(
+      headers == null || imageRenderMethodForWeb == platform.ImageRenderMethodForWeb.HttpGet,
+      'Headers are only supported with ImageRenderMethodForWeb.HttpGet. '
+      'HtmlImage does not support custom headers. '
+      'Please use ImageRenderMethodForWeb.HttpGet when providing headers.',
+    );
+
     switch (imageRenderMethodForWeb) {
       case platform.ImageRenderMethodForWeb.HttpGet:
         return _loadAsyncHttpGet(

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -109,13 +109,16 @@ class ImageLoader implements platform.ImageLoader {
     VoidCallback evictImage,
   ) {
     // Ensure HttpGet is used when headers are provided
-    assert(
-      headers == null ||
-          imageRenderMethodForWeb == platform.ImageRenderMethodForWeb.HttpGet,
-      'Headers are only supported with ImageRenderMethodForWeb.HttpGet. '
-      'HtmlImage does not support custom headers. '
-      'Please use ImageRenderMethodForWeb.HttpGet when providing headers.',
-    );
+    if (headers != null &&
+        imageRenderMethodForWeb != platform.ImageRenderMethodForWeb.HttpGet) {
+      throw ArgumentError.value(
+        imageRenderMethodForWeb,
+        'imageRenderMethodForWeb',
+        'Headers are only supported with ImageRenderMethodForWeb.HttpGet. '
+        'HtmlImage does not support custom headers. '
+        'Please use ImageRenderMethodForWeb.HttpGet when providing headers.',
+      );
+    }
 
     switch (imageRenderMethodForWeb) {
       case platform.ImageRenderMethodForWeb.HttpGet:

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -110,7 +110,8 @@ class ImageLoader implements platform.ImageLoader {
   ) {
     // Ensure HttpGet is used when headers are provided
     assert(
-      headers == null || imageRenderMethodForWeb == platform.ImageRenderMethodForWeb.HttpGet,
+      headers == null ||
+          imageRenderMethodForWeb == platform.ImageRenderMethodForWeb.HttpGet,
       'Headers are only supported with ImageRenderMethodForWeb.HttpGet. '
       'HtmlImage does not support custom headers. '
       'Please use ImageRenderMethodForWeb.HttpGet when providing headers.',

--- a/cached_network_image_web/test/cached_network_image_web_ce_test.dart
+++ b/cached_network_image_web/test/cached_network_image_web_ce_test.dart
@@ -45,24 +45,49 @@ void main() {
     expect(stream, isNotNull);
   });
 
-  test('loadImageAsync with HtmlImage and headers throws assertion error', () {
-    final imageLoader = ImageLoader();
-    expect(
-      () => imageLoader.loadImageAsync(
-        'test.com/image',
-        null,
-        StreamController<ImageChunkEvent>(),
-        decoder,
-        MockCacheManager(),
-        null,
-        null,
-        {'Authorization': 'Bearer token'},
-        ImageRenderMethodForWeb.HtmlImage,
-        () => {},
-      ),
-      throwsAssertionError,
-    );
-  });
+  test(
+    'loadImageAsync with HtmlImage and headers throws ArgumentError',
+    () {
+      final imageLoader = ImageLoader();
+      expect(
+        () => imageLoader.loadImageAsync(
+          'test.com/image',
+          null,
+          StreamController<ImageChunkEvent>(),
+          decoder,
+          MockCacheManager(),
+          null,
+          null,
+          {'Authorization': 'Bearer token'},
+          ImageRenderMethodForWeb.HtmlImage,
+          () => {},
+        ),
+        throwsArgumentError,
+      );
+    },
+  );
+
+  test(
+    'loadBufferAsync with HtmlImage and headers throws ArgumentError',
+    () {
+      final imageLoader = ImageLoader();
+      expect(
+        () => imageLoader.loadBufferAsync(
+          'test.com/image',
+          null,
+          StreamController<ImageChunkEvent>(),
+          bufferDecoder,
+          MockCacheManager(),
+          null,
+          null,
+          {'Authorization': 'Bearer token'},
+          ImageRenderMethodForWeb.HtmlImage,
+          () => {},
+        ),
+        throwsArgumentError,
+      );
+    },
+  );
 
   test('loadImageAsync with HttpGet and headers works', () {
     final imageLoader = ImageLoader();

--- a/cached_network_image_web/test/cached_network_image_web_ce_test.dart
+++ b/cached_network_image_web/test/cached_network_image_web_ce_test.dart
@@ -44,6 +44,61 @@ void main() {
     );
     expect(stream, isNotNull);
   });
+
+  test('loadImageAsync with HtmlImage and headers throws assertion error', () {
+    final imageLoader = ImageLoader();
+    expect(
+      () => imageLoader.loadImageAsync(
+        'test.com/image',
+        null,
+        StreamController<ImageChunkEvent>(),
+        decoder,
+        MockCacheManager(),
+        null,
+        null,
+        {'Authorization': 'Bearer token'},
+        ImageRenderMethodForWeb.HtmlImage,
+        () => {},
+      ),
+      throwsAssertionError,
+    );
+  });
+
+  test('loadImageAsync with HttpGet and headers works', () {
+    final imageLoader = ImageLoader();
+    final stream = imageLoader.loadImageAsync(
+      'test.com/image',
+      null,
+      StreamController<ImageChunkEvent>(),
+      decoder,
+      MockCacheManager(),
+      null,
+      null,
+      {'Authorization': 'Bearer token'},
+      ImageRenderMethodForWeb.HttpGet,
+      () => {},
+    );
+    expect(stream, isNotNull);
+  });
+
+  test('loadImageAsync with HtmlImage and no headers works', () {
+    final imageLoader = ImageLoader();
+    // This test would need actual image data to complete the stream,
+    // so we just verify that the stream is created without assertion error
+    final stream = imageLoader.loadImageAsync(
+      'test.com/image',
+      null,
+      StreamController<ImageChunkEvent>(),
+      decoder,
+      MockCacheManager(),
+      null,
+      null,
+      null,
+      ImageRenderMethodForWeb.HtmlImage,
+      () => {},
+    );
+    expect(stream, isNotNull);
+  });
 }
 
 Future<ui.Codec> decoder(


### PR DESCRIPTION
Implement a runtime assertion to ensure that custom headers are only used with the HttpGet render method on the Web.

## Description

Implement a runtime assertion to ensure that custom headers are only used with the HttpGet render method on the Web. Update documentation to clarify this requirement and provide examples. Add tests to verify the assertion behavior and successful usage of headers with HttpGet.

## Related Issues

Resolves #14

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Web guidance on custom header support, added usage examples, and noted caching behavior when using HTTP fetch on Web.

* **Improvements**
  * Added runtime validation to ensure headers are only used with the appropriate Web render method.

* **Tests**
  * Added tests covering header handling across Web render methods to verify correct behavior and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->