### PR TITLE
Ensure cache directory exists before file operations

### DIFF
--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -186,6 +186,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     return path.join(_cacheDir!, relativePath);
   }
 
+  Future<void> _ensureCacheDirectoryExists() async {
+    await io.Directory(_cacheDir!).create(recursive: true);
+  }
+
   /// Builds a relative file path from key and extension.
   String _generateRelativePath(String key, String fileExtension) {
     final hash = key.hashCode.toUnsigned(32).toRadixString(16);
@@ -309,6 +313,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final fileExtension = _getFileExtensionFromUrl(url);
       final relativePath = _generateRelativePath(key, fileExtension);
       final filePath = _cacheFilePath(relativePath);
+
+      await _ensureCacheDirectoryExists();
+
       final tempFilePath =
           '$filePath.${DateTime.now().microsecondsSinceEpoch}.tmp';
       final tempFile = io.File(tempFilePath);
@@ -438,6 +445,8 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     key ??= url;
     final relativePath = _generateRelativePath(key, fileExtension);
     final filePath = _cacheFilePath(relativePath);
+
+    await _ensureCacheDirectoryExists();
 
     final file = io.File(filePath);
     await file.writeAsBytes(fileBytes);

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -511,9 +511,18 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     }
 
     if (_cacheBox != null && _cacheBox!.isOpen) {
-      await _cacheBox!.close();
+      try {
+        await _cacheBox!.close();
+      } on Object catch (_) {
+        // Ignore errors when closing box (e.g. PathNotFoundException if the
+        // cache directory was deleted before dispose was called).
+      }
     }
-    await _hive.close();
+    try {
+      await _hive.close();
+    } on Object catch (_) {
+      // Ignore errors when closing Hive (e.g. residual lock file already gone).
+    }
 
     _cacheBox = null;
     _cacheDir = null;

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -557,8 +557,7 @@ void main() {
   // ---- Issue 3: Cache directory / Hive metadata resilience ----
 
   group('Regression: cache directory resilience', () {
-    test(
-        'recreates cache directory if deleted during lifetime before putFile',
+    test('recreates cache directory if deleted during lifetime before putFile',
         () async {
       final customDir =
           io.Directory.systemTemp.createTempSync('resilience_runtime_put_');
@@ -598,8 +597,7 @@ void main() {
       await manager.emptyCache();
     });
 
-    test(
-        'recreates cache directory if deleted during lifetime before download',
+    test('recreates cache directory if deleted during lifetime before download',
         () async {
       final customDir = io.Directory.systemTemp
           .createTempSync('resilience_runtime_download_');
@@ -629,7 +627,8 @@ void main() {
       }
 
       final events = await manager
-          .getFileStream('https://example.com/runtime-download-after-delete.png')
+          .getFileStream(
+              'https://example.com/runtime-download-after-delete.png')
           .toList();
       final fileInfos = events.whereType<FileInfo>().toList();
       expect(fileInfos, isNotEmpty);

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -595,6 +595,7 @@ void main() {
       expect(cached, isNotNull);
 
       await manager.emptyCache();
+      await manager.dispose();
     });
 
     test('recreates cache directory if deleted during lifetime before download',
@@ -634,6 +635,7 @@ void main() {
       expect(fileInfos, isNotEmpty);
 
       await manager.emptyCache();
+      await manager.dispose();
     });
 
     test('recovers when Hive metadata dir is deleted but cache files remain',

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -557,6 +557,86 @@ void main() {
   // ---- Issue 3: Cache directory / Hive metadata resilience ----
 
   group('Regression: cache directory resilience', () {
+    test(
+        'recreates cache directory if deleted during lifetime before putFile',
+        () async {
+      final customDir =
+          io.Directory.systemTemp.createTempSync('resilience_runtime_put_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+      );
+
+      await manager.putFile(
+        'https://example.com/runtime-put-initial.bin',
+        [1],
+        fileExtension: 'bin',
+      );
+
+      final cacheSubDir =
+          io.Directory('${customDir.path}/cached_network_image_ce');
+      if (cacheSubDir.existsSync()) {
+        cacheSubDir.deleteSync(recursive: true);
+      }
+
+      await manager.putFile(
+        'https://example.com/runtime-put-after-delete.bin',
+        [2, 3],
+        fileExtension: 'bin',
+      );
+
+      final cached = await manager.getFileFromCache(
+        'https://example.com/runtime-put-after-delete.bin',
+      );
+      expect(cached, isNotNull);
+
+      await manager.emptyCache();
+    });
+
+    test(
+        'recreates cache directory if deleted during lifetime before download',
+        () async {
+      final customDir = io.Directory.systemTemp
+          .createTempSync('resilience_runtime_download_');
+      addTearDown(() {
+        try {
+          customDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => customDir,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('runtime-download', 200),
+        ),
+      );
+
+      await manager.putFile(
+        'https://example.com/runtime-download-initial.bin',
+        [1],
+        fileExtension: 'bin',
+      );
+
+      final cacheSubDir =
+          io.Directory('${customDir.path}/cached_network_image_ce');
+      if (cacheSubDir.existsSync()) {
+        cacheSubDir.deleteSync(recursive: true);
+      }
+
+      final events = await manager
+          .getFileStream('https://example.com/runtime-download-after-delete.png')
+          .toList();
+      final fileInfos = events.whereType<FileInfo>().toList();
+      expect(fileInfos, isNotEmpty);
+
+      await manager.emptyCache();
+    });
+
     test('recovers when Hive metadata dir is deleted but cache files remain',
         () async {
       final customDir =

--- a/cached_network_image_web/test/cached_network_image_web_ce_test.dart
+++ b/cached_network_image_web/test/cached_network_image_web_ce_test.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: deprecated_member_use_from_same_package
+@TestOn('browser')
+library;
 
 import 'dart:async';
 import 'dart:ui' as ui;


### PR DESCRIPTION
## Description

Implement a check to ensure the cache directory exists prior to performing file operations, enhancing resilience against directory deletion.

## Related Issues

Resolves #15
Relates to
https://github.com/Baseflow/flutter_cached_network_image/issues/1027

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache resilience by ensuring cache directories are recreated when missing before file writes and download finalization, reducing runtime errors and race conditions.

* **Tests**
  * Added regression tests that validate cache directory recovery for both direct writes and download flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->