### PR TITLE
Add key sanitization to handle Hive's 255-character limit

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.6.4] - 2026-03-24
+
+* **Fix:** Resolve `HiveError` crashes caused by URL string keys exceeding 255 characters. Long cache keys are now automatically hashed using SHA-256 to remain under Hive's 255-character length limit.
+
 ## [4.6.3] - 2026-03-15
 
 * **Fix:** Handle exceptions when closing the Hive cache box and Hive instance during `dispose()`. (PR #17)

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' as io;
 import 'dart:math';
 import 'dart:ui' as ui;
 
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
+import 'package:crypto/crypto.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
@@ -24,6 +26,14 @@ const _kDefaultMaxCacheObjects = 200;
 const _kDefaultStalePeriod = Duration(days: 7);
 
 const _supportedFileNames = ['jpg', 'jpeg', 'png', 'tga', 'cur', 'ico'];
+
+/// Sanitizes a key so it doesn't exceed Hive's 255-character limit for string keys.
+String _sanitizeBoxKey(String key) {
+  if (key.length <= 255) return key;
+  final hash = sha256.convert(utf8.encode(key)).toString();
+  // 255 max limit. 255 - 64 (sha256 hex length) - 1 (underscore) = 190
+  return '${key.substring(0, 190)}_$hash';
+}
 
 /// Signature for a function that returns the cache base directory.
 ///
@@ -390,7 +400,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final eTag = cacheHeaders['etag'];
 
       await _cacheBox!.put(
-          key,
+          _sanitizeBoxKey(key),
           CacheEntryMetadata(
             url: url,
             relativePath: relativePath,
@@ -413,7 +423,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   }) async {
     await _ensureInitialized();
 
-    final raw = _cacheBox!.get(key);
+    final raw = _cacheBox!.get(_sanitizeBoxKey(key));
     if (raw == null) return null;
 
     final metadata = CacheEntryMetadata.fromMap(raw);
@@ -422,7 +432,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     final file = io.File(filePath);
     if (!file.existsSync()) {
       // Metadata exists but file is missing, clean up
-      await _cacheBox!.delete(key);
+      await _cacheBox!.delete(_sanitizeBoxKey(key));
       return null;
     }
 
@@ -453,7 +463,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
     final validTill = DateTime.now().add(maxAge);
     _cacheBox!.put(
-        key,
+        _sanitizeBoxKey(key),
         CacheEntryMetadata(
           url: url,
           relativePath: relativePath,
@@ -469,14 +479,14 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   Future<void> removeFile(String key) async {
     await _ensureInitialized();
 
-    final raw = _cacheBox!.get(key);
+    final raw = _cacheBox!.get(_sanitizeBoxKey(key));
     if (raw != null) {
       final metadata = CacheEntryMetadata.fromMap(raw);
       final file = io.File(_cacheFilePath(metadata.relativePath));
       if (await file.exists()) {
         await file.delete();
       }
-      await _cacheBox!.delete(key);
+      await _cacheBox!.delete(_sanitizeBoxKey(key));
     }
   }
 

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
+import 'package:crypto/crypto.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
@@ -18,6 +20,14 @@ const _kDataBoxName = 'cached_network_image_data';
 const _kDefaultMaxAge = Duration(days: 30);
 const _kDefaultMaxCacheObjects = 200;
 const _kDefaultStalePeriod = Duration(days: 7);
+
+/// Sanitizes a key so it doesn't exceed Hive's 255-character limit for string keys.
+String _sanitizeBoxKey(String key) {
+  if (key.length <= 255) return key;
+  final hash = sha256.convert(utf8.encode(key)).toString();
+  // 255 max limit. 255 - 64 (sha256 hex length) - 1 (underscore) = 190
+  return '${key.substring(0, 190)}_$hash';
+}
 
 /// Web-specific [DefaultCacheManager] that stores both metadata and raw
 /// image bytes in Hive boxes (backed by IndexedDB on web).
@@ -286,7 +296,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
           '${key.hashCode.toUnsigned(32).toRadixString(16)}.$fileExtension';
 
       await _metaBox!.put(
-        key,
+        _sanitizeBoxKey(key),
         CacheEntryMetadata(
           url: url,
           relativePath: relativePath,
@@ -295,7 +305,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
           length: receivedBytes,
         ).toMap(),
       );
-      await _dataBox!.put(key, allBytes);
+      await _dataBox!.put(_sanitizeBoxKey(key), allBytes);
 
       final file = _bytesToFile(relativePath, allBytes);
       yield FileInfo(file, FileSource.Online, validTill, url);
@@ -311,15 +321,15 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   }) async {
     await _ensureInitialized();
 
-    final raw = _metaBox!.get(key);
+    final raw = _metaBox!.get(_sanitizeBoxKey(key));
     if (raw == null) return null;
 
     final metadata = CacheEntryMetadata.fromMap(raw);
 
-    final bytes = await _dataBox!.get(key);
+    final bytes = await _dataBox!.get(_sanitizeBoxKey(key));
     if (bytes == null) {
       // Metadata exists but data is missing — clean up.
-      await _metaBox!.delete(key);
+      await _metaBox!.delete(_sanitizeBoxKey(key));
       return null;
     }
 
@@ -349,7 +359,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     final validTill = DateTime.now().add(maxAge);
 
     await _metaBox!.put(
-      key,
+      _sanitizeBoxKey(key),
       CacheEntryMetadata(
         url: url,
         relativePath: relativePath,
@@ -358,7 +368,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         length: fileBytes.length,
       ).toMap(),
     );
-    await _dataBox!.put(key, fileBytes);
+    await _dataBox!.put(_sanitizeBoxKey(key), fileBytes);
 
     return _bytesToFile(relativePath, fileBytes);
   }
@@ -366,7 +376,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   @override
   Future<void> removeFile(String key) async {
     await _ensureInitialized();
-    final raw = _metaBox!.get(key);
+    final raw = _metaBox!.get(_sanitizeBoxKey(key));
     if (raw != null) {
       final metadata = CacheEntryMetadata.fromMap(raw);
       try {
@@ -381,8 +391,8 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         );
       }
     }
-    await _metaBox!.delete(key);
-    await _dataBox!.delete(key);
+    await _metaBox!.delete(_sanitizeBoxKey(key));
+    await _dataBox!.delete(_sanitizeBoxKey(key));
   }
 
   @override

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.6.3
+version: 4.6.4
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -16,6 +16,7 @@ environment:
 dependencies:
   cached_network_image_platform_interface_ce: ^5.2.0
   cached_network_image_web_ce: ^2.1.0
+  crypto: ^3.0.0
   file: '>=7.0.0 <8.0.0'
   flutter:
     sdk: flutter

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1711,6 +1711,36 @@ void main() {
           reason: 'http.Client must be closed even on timeout');
     });
   });
+
+  // ---- Hive String Key Length Limit ----
+
+  group('Hive string key length limit fix', () {
+    test('handles keys longer than 255 characters without HiveError', () async {
+      final manager = DefaultCacheManager(
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('data', 200),
+        ),
+      );
+
+      final longKey = 'https://example.com/very-long-url-'.padRight(300, 'a');
+
+      // 1. putFile
+      await manager.putFile(longKey, [1, 2, 3], fileExtension: 'bin');
+
+      // 2. getFileFromCache
+      final cached = await manager.getFileFromCache(longKey);
+      expect(cached, isNotNull);
+      expect(cached!.originalUrl, longKey);
+
+      // 3. removeFile
+      await manager.removeFile(longKey);
+      final cachedAfterRemove = await manager.getFileFromCache(longKey);
+      expect(cachedAfterRemove, isNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
 }
 
 /// A wrapper around [http.Client] that tracks whether [close] was called.

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -1132,6 +1132,37 @@ void main() {
           reason: 'http.Client must be closed even on timeout');
     });
   });
+
+  // ---- Hive String Key Length Limit ----
+
+  group('Hive string key length limit fix', () {
+    test('handles keys longer than 255 characters without HiveError', () async {
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () => http_testing.MockClient(
+          (request) async => http.Response('data', 200),
+        ),
+      );
+
+      final longKey = 'https://example.com/very-long-url-'.padRight(300, 'a');
+
+      // 1. putFile
+      await manager.putFile(longKey, [1, 2, 3], fileExtension: 'bin');
+
+      // 2. getFileFromCache
+      final cached = await manager.getFileFromCache(longKey);
+      expect(cached, isNotNull);
+      expect(cached!.originalUrl, longKey);
+
+      // 3. removeFile
+      await manager.removeFile(longKey);
+      final cachedAfterRemove = await manager.getFileFromCache(longKey);
+      expect(cachedAfterRemove, isNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
 }
 
 /// A wrapper around [http.Client] that tracks whether [close] was called.


### PR DESCRIPTION
## Description

Implement key sanitization to ensure that keys do not exceed Hive's 255-character limit, preventing potential errors. This change includes updates to the cache manager and corresponding tests to verify functionality.

## Related Issues

Fixes #19

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed crashes that occurred when cache keys exceeded the 255-character limit. Long cache keys are now automatically handled to prevent errors and ensure consistent cache behavior.

* **Tests**
  * Added regression tests to verify cache operations work correctly with lengthy cache keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->