### PR TITLE
GIF image set minimum frame duration (-> 100ms)

### DIFF
--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -75,11 +75,16 @@ class CachedNetworkImage extends StatefulWidget {
     String? cacheKey,
     BaseCacheManager? cacheManager,
     double scale = 1,
+    Duration minimumGifFrameDuration = const Duration(milliseconds: 100),
   }) async {
     final effectiveCacheManager =
         cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
     await effectiveCacheManager.removeFile(cacheKey ?? url);
-    return CachedNetworkImageProvider(url, scale: scale).evict();
+    return CachedNetworkImageProvider(
+      url,
+      scale: scale,
+      minimumGifFrameDuration: minimumGifFrameDuration,
+    ).evict();
   }
 
   /// Option to use cacheManager with other settings
@@ -253,6 +258,10 @@ class CachedNetworkImage extends StatefulWidget {
   /// Scale of the image.
   final double scale;
 
+  /// The minimum frame duration applied to GIF images when decoded frame
+  /// durations are extremely short.
+  final Duration minimumGifFrameDuration;
+
   /// When true (the default), the placeholder and fade-in/out animations are
   /// skipped when the image is already available in the disk cache. This
   /// prevents an unnecessary visual flicker for images that load almost
@@ -300,6 +309,7 @@ class CachedNetworkImage extends StatefulWidget {
     this.errorListener,
     this.imageRenderMethodForWeb = ImageRenderMethodForWeb.HtmlImage,
     this.scale = 1.0,
+    this.minimumGifFrameDuration = const Duration(milliseconds: 100),
     this.disablePlaceholderOnCacheHit = true,
   });
 
@@ -344,6 +354,7 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
         oldWidget.maxHeightDiskCache != widget.maxHeightDiskCache ||
         oldWidget.imageRenderMethodForWeb != widget.imageRenderMethodForWeb ||
         oldWidget.scale != widget.scale ||
+        oldWidget.minimumGifFrameDuration != widget.minimumGifFrameDuration ||
         oldWidget.errorListener != widget.errorListener;
 
     if (imageConfigChanged) {
@@ -373,6 +384,7 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
       maxHeight: widget.maxHeightDiskCache,
       errorListener: widget.errorListener,
       scale: widget.scale,
+      minimumGifFrameDuration: widget.minimumGifFrameDuration,
     );
   }
 

--- a/cached_network_image/lib/src/gif_frame_duration.dart
+++ b/cached_network_image/lib/src/gif_frame_duration.dart
@@ -1,0 +1,10 @@
+Duration clampGifFrameDuration(
+  Duration frameDuration, {
+  Duration minimumGifFrameDuration = const Duration(milliseconds: 100),
+}) {
+  if (frameDuration <= const Duration(milliseconds: 10)) {
+    return minimumGifFrameDuration;
+  }
+
+  return frameDuration;
+}

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -23,6 +23,7 @@ class CachedNetworkImageProvider
     this.maxHeight,
     this.maxWidth,
     this.scale = 1.0,
+    this.minimumGifFrameDuration = const Duration(milliseconds: 100),
     this.errorListener,
     this.headers,
     this.cacheManager,
@@ -44,6 +45,10 @@ class CachedNetworkImageProvider
 
   /// Scale of the image
   final double scale;
+
+  /// The minimum frame duration applied to GIF images when decoded frame
+  /// durations are extremely short.
+  final Duration minimumGifFrameDuration;
 
   /// Listener to be called when images fails to load.
   ///
@@ -90,6 +95,7 @@ class CachedNetworkImageProvider
       codec: _loadBufferAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
+      minimumGifFrameDuration: key.minimumGifFrameDuration,
       informationCollector: () => <DiagnosticsNode>[
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),
@@ -163,6 +169,7 @@ class CachedNetworkImageProvider
       codec: _loadImageAsync(key, chunkEvents, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
+      minimumGifFrameDuration: key.minimumGifFrameDuration,
       informationCollector: () => <DiagnosticsNode>[
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),
@@ -230,6 +237,7 @@ class CachedNetworkImageProvider
     if (other is CachedNetworkImageProvider) {
       return ((cacheKey ?? url) == (other.cacheKey ?? other.url)) &&
           scale == other.scale &&
+          minimumGifFrameDuration == other.minimumGifFrameDuration &&
           maxHeight == other.maxHeight &&
           maxWidth == other.maxWidth;
     }
@@ -237,8 +245,18 @@ class CachedNetworkImageProvider
   }
 
   @override
-  int get hashCode => Object.hash(cacheKey ?? url, scale, maxHeight, maxWidth);
+  int get hashCode => Object.hash(
+        cacheKey ?? url,
+        scale,
+        minimumGifFrameDuration,
+        maxHeight,
+        maxWidth,
+      );
 
   @override
-  String toString() => 'CachedNetworkImageProvider("$url", scale: $scale)';
+  String toString() => 'CachedNetworkImageProvider('
+      '"$url", '
+      'scale: $scale, '
+      'minimumGifFrameDuration: $minimumGifFrameDuration'
+      ')';
 }

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -20,8 +20,8 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     required double scale,
     Stream<ImageChunkEvent>? chunkEvents,
     InformationCollector? informationCollector,
-  })  : _informationCollector = informationCollector,
-        _scale = scale {
+  }) : _informationCollector = informationCollector,
+       _scale = scale {
     codec.listen(
       (event) {
         if (_timer != null) {
@@ -104,6 +104,9 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
       _emitFrame(ImageInfo(image: _nextFrame!.image, scale: _scale));
       _shownTimestamp = timestamp;
       _frameDuration = _nextFrame!.duration;
+      if (_frameDuration! <= const Duration(milliseconds: 10)) {
+        _frameDuration = const Duration(milliseconds: 100);
+      }
       _nextFrame = null;
       if (_framesEmitted % _codec!.frameCount == 0 && _nextImageCodec != null) {
         _switchToNewCodec();

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui' as ui show Codec, FrameInfo;
 
+import 'package:cached_network_image_ce/src/gif_frame_duration.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/scheduler.dart';
@@ -20,8 +21,9 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     required double scale,
     Stream<ImageChunkEvent>? chunkEvents,
     InformationCollector? informationCollector,
-  }) : _informationCollector = informationCollector,
-       _scale = scale {
+    this.minimumGifFrameDuration = const Duration(milliseconds: 100),
+  })  : _informationCollector = informationCollector,
+        _scale = scale {
     codec.listen(
       (event) {
         if (_timer != null) {
@@ -60,6 +62,12 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
   ui.Codec? _nextImageCodec;
   final double _scale;
   final InformationCollector? _informationCollector;
+
+  /// The minimum frame duration applied to GIF images when decoded frame
+  /// durations are extremely short.
+  ///
+  /// Defaults to 100ms.
+  final Duration minimumGifFrameDuration;
   ui.FrameInfo? _nextFrame;
 
   // When the current was first shown.
@@ -103,10 +111,10 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     if (_isFirstFrame() || _hasFrameDurationPassed(timestamp)) {
       _emitFrame(ImageInfo(image: _nextFrame!.image, scale: _scale));
       _shownTimestamp = timestamp;
-      _frameDuration = _nextFrame!.duration;
-      if (_frameDuration! <= const Duration(milliseconds: 10)) {
-        _frameDuration = const Duration(milliseconds: 100);
-      }
+      _frameDuration = clampGifFrameDuration(
+        _nextFrame!.duration,
+        minimumGifFrameDuration: minimumGifFrameDuration,
+      );
       _nextFrame = null;
       if (_framesEmitted % _codec!.frameCount == 0 && _nextImageCodec != null) {
         _switchToNewCodec();

--- a/cached_network_image/test/cached_network_image_provider_test.dart
+++ b/cached_network_image/test/cached_network_image_provider_test.dart
@@ -54,6 +54,21 @@ void main() {
         expect(a, isNot(equals(b)));
       });
 
+      test(
+          'providers with different minimumGifFrameDuration values are not equal',
+          () {
+        const a = CachedNetworkImageProvider(
+          'https://example.com/img.png',
+          minimumGifFrameDuration: Duration(milliseconds: 100),
+        );
+        const b = CachedNetworkImageProvider(
+          'https://example.com/img.png',
+          minimumGifFrameDuration: Duration(milliseconds: 200),
+        );
+
+        expect(a, isNot(equals(b)));
+      });
+
       test('different maxHeight are not equal', () {
         const a = CachedNetworkImageProvider(
           'https://example.com/img.png',
@@ -95,6 +110,7 @@ void main() {
         const b = CachedNetworkImageProvider(
           'https://example.com/img.png',
           scale: 2.0,
+          minimumGifFrameDuration: Duration(milliseconds: 100),
           maxHeight: 100,
           maxWidth: 200,
         );
@@ -119,10 +135,12 @@ void main() {
         const provider = CachedNetworkImageProvider(
           'https://example.com/img.png',
           scale: 2.0,
+          minimumGifFrameDuration: Duration(milliseconds: 150),
         );
         final result = provider.toString();
         expect(result, contains('https://example.com/img.png'));
         expect(result, contains('2.0'));
+        expect(result, contains('0:00:00.150000'));
       });
     });
 

--- a/cached_network_image/test/image_stream_completer_test.dart
+++ b/cached_network_image/test/image_stream_completer_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:cached_network_image_ce/src/gif_frame_duration.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter_test/flutter_test.dart';
@@ -84,6 +85,36 @@ void main() {
     image20x10 = await createTestImage(width: 20, height: 10);
     image200x100 = await createTestImage(width: 200, height: 100);
     image300x100 = await createTestImage(width: 300, height: 100);
+  });
+
+  group('clampGifFrameDuration', () {
+    test('clamps frame durations at or below 10ms', () {
+      expect(
+        clampGifFrameDuration(
+          const Duration(milliseconds: 10),
+          minimumGifFrameDuration: const Duration(milliseconds: 100),
+        ),
+        const Duration(milliseconds: 100),
+      );
+
+      expect(
+        clampGifFrameDuration(
+          const Duration(milliseconds: 5),
+          minimumGifFrameDuration: const Duration(milliseconds: 80),
+        ),
+        const Duration(milliseconds: 80),
+      );
+    });
+
+    test('keeps frame durations above 10ms unchanged', () {
+      expect(
+        clampGifFrameDuration(
+          const Duration(milliseconds: 11),
+          minimumGifFrameDuration: const Duration(milliseconds: 100),
+        ),
+        const Duration(milliseconds: 11),
+      );
+    });
   });
 
   testWidgets('Codec future fails', (WidgetTester tester) async {
@@ -494,6 +525,57 @@ void main() {
     // quit the test without pending timers.
     await tester.pump(const Duration(milliseconds: 400));
   });
+
+  testWidgets(
+    'short GIF frame durations are clamped to minimumGifFrameDuration',
+    (WidgetTester tester) async {
+      final mockCodec = MockCodec()
+        ..frameCount = 2
+        ..repetitionCount = -1;
+
+      final codecStream = StreamController<Codec>();
+
+      final ImageStreamCompleter imageStream = MultiImageStreamCompleter(
+        codec: codecStream.stream,
+        scale: 1.0,
+        minimumGifFrameDuration: const Duration(milliseconds: 100),
+      );
+
+      final emittedImages = <ImageInfo>[];
+      imageStream.addListener(
+        ImageStreamListener((ImageInfo image, bool synchronousCall) {
+          emittedImages.add(image);
+        }),
+      );
+
+      codecStream.add(mockCodec);
+      await tester.idle();
+
+      final FrameInfo frame1 =
+          FakeFrameInfo(const Duration(milliseconds: 10), image20x10);
+      mockCodec.completeNextFrame(frame1);
+      await tester.idle();
+      await tester.pump();
+
+      expect(emittedImages.length, 1);
+      expect(emittedImages.single.image.isCloneOf(frame1.image), true);
+
+      final FrameInfo frame2 =
+          FakeFrameInfo(const Duration(milliseconds: 200), image200x100);
+      mockCodec.completeNextFrame(frame2);
+      await tester.idle();
+
+      // The first frame duration is 10ms, but it should be clamped to 100ms.
+      await tester.pump(const Duration(milliseconds: 99));
+      expect(emittedImages.length, 1);
+
+      await tester.pump(const Duration(milliseconds: 1));
+      expect(emittedImages.length, 2);
+      expect(emittedImages[1].image.isCloneOf(frame2.image), true);
+
+      await tester.pump(const Duration(milliseconds: 200));
+    },
+  );
 
   testWidgets('animation wraps back', (WidgetTester tester) async {
     final mockCodec = MockCodec();


### PR DESCRIPTION
## Description
This PR fixes an issue where some GIFs can play too fast when frame durations are extremely short.

If a decoded frame duration is 10ms or less, it is clamped to 100ms to improve playback consistency.

## Related Issues
- N/A

## Checklist
- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [ ] I've added new tests for any new features or bug fixes
- [ ] I've updated the CHANGELOG if applicable

## Additional context
Very short GIF frame durations can lead to unnaturally fast playback. Some browsers, including Chrome, apply a minimum frame duration during playback.

Reference:
-  https://source.chromium.org/chromium/chromium/src/+/refs/tags/98.0.4754.1:third_party/blink/renderer/platform/graphics/deferred_image_decoder.cc;l=353

Demo:

https://github.com/user-attachments/assets/d7b0017f-171e-4776-8ac5-58c86798713d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `minimumGifFrameDuration` parameter to `CachedNetworkImage` widget and `CachedNetworkImageProvider`, defaulting to 100ms.
  * Added `minimumGifFrameDuration` parameter to `CachedNetworkImage.evictFromCache()` method.

* **Tests**
  * Added tests for GIF frame duration handling and timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->