### PR TITLE
Fix import in example in README.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The API is identical to the original package. You can use `CachedNetworkImage` d
 ### Basic Usage with Placeholder
 
 ```dart
-import 'package:cached_network_image_ce/cached_network_image_ce.dart';
+import 'package:cached_network_image_ce/cached_network_image.dart';
 
 CachedNetworkImage(
   imageUrl: '[https://via.placeholder.com/350x150](https://via.placeholder.com/350x150)',

--- a/README.md
+++ b/README.md
@@ -139,5 +139,3 @@ We welcome contributions! If you want to help maintain this essential package, p
 ## 📄 License
 
 This project is licensed under the MIT License.
-
-```


### PR DESCRIPTION
## Description

The example in README.md uses "_ce" suffix in both package name and file name. The latter however is just called "cached_network_image.dart".

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [ ] I've added new tests for any new features or bug fixes
- [ ] I've updated the CHANGELOG if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Dart import example to reference the correct package API entrypoint so sample code matches the published API, preventing import issues and clarifying usage for developers.
  * Fixed README formatting so the file now ends cleanly with a newline, removed stray formatting artifacts, and improved overall documentation consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->