### PR TITLE
Replace Hive_CE Box calls with LazyBox

### DIFF
--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -85,7 +85,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// Hive registry.
   final HiveInterface _hive = HiveImpl();
 
-  Box<Map>? _cacheBox;
+  LazyBox<Map>? _cacheBox;
   String? _cacheDir;
 
   /// Guards [_doInit] so that concurrent callers (e.g. multiple images
@@ -133,7 +133,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     // This avoids calling Hive.init() which would conflict with the
     // host application's own Hive initialization.
     try {
-      _cacheBox = await _hive.openBox<Map>(_kBoxName, path: hivePath);
+      _cacheBox = await _hive.openLazyBox<Map>(_kBoxName, path: hivePath);
     } on HiveError catch (e) {
       // Box corruption (e.g. "Cannot read, unknown typeId: 121").
       // Since this is a cache, we can safely delete the corrupted box
@@ -143,7 +143,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         CacheManagerLogLevel.warning,
       );
       await _safeDeleteBox(_kBoxName, hivePath);
-      _cacheBox = await _hive.openBox<Map>(_kBoxName, path: hivePath);
+      _cacheBox = await _hive.openLazyBox<Map>(_kBoxName, path: hivePath);
 
       // Also remove cached files since their metadata is gone.
       await _deleteCacheFiles();
@@ -423,7 +423,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   }) async {
     await _ensureInitialized();
 
-    final raw = _cacheBox!.get(_sanitizeBoxKey(key));
+    final raw = await _cacheBox!.get(_sanitizeBoxKey(key));
     if (raw == null) return null;
 
     final metadata = CacheEntryMetadata.fromMap(raw);
@@ -479,7 +479,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   Future<void> removeFile(String key) async {
     await _ensureInitialized();
 
-    final raw = _cacheBox!.get(_sanitizeBoxKey(key));
+    final raw = await _cacheBox!.get(_sanitizeBoxKey(key));
     if (raw != null) {
       final metadata = CacheEntryMetadata.fromMap(raw);
       final file = io.File(_cacheFilePath(metadata.relativePath));
@@ -496,7 +496,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
     // Delete all cached files
     for (final key in _cacheBox!.keys.toList()) {
-      final raw = _cacheBox!.get(key);
+      final raw = await _cacheBox!.get(key);
       if (raw != null) {
         final metadata = CacheEntryMetadata.fromMap(raw);
         final file = io.File(_cacheFilePath(metadata.relativePath));
@@ -546,7 +546,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final entries = <MapEntry<dynamic, CacheEntryMetadata>>[];
 
       for (final key in _cacheBox!.keys.toList()) {
-        final raw = _cacheBox!.get(key);
+        final raw = await _cacheBox!.get(key);
         if (raw != null) {
           entries.add(MapEntry(key, CacheEntryMetadata.fromMap(raw)));
         }

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -134,6 +134,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     // host application's own Hive initialization.
     try {
       _cacheBox = await _hive.openLazyBox<Map>(_kBoxName, path: hivePath);
+      // LazyBox only reads frame headers at open; probe every value so a
+      // corrupt typeId throws here and triggers the recovery path below
+      // instead of surfacing later from a swallowed background read.
+      for (final key in _cacheBox!.keys.toList()) {
+        await _cacheBox!.get(key);
+      }
     } on HiveError catch (e) {
       // Box corruption (e.g. "Cannot read, unknown typeId: 121").
       // Since this is a cache, we can safely delete the corrupted box
@@ -142,6 +148,11 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         'CacheManager: Hive box corrupted, resetting cache: $e',
         CacheManagerLogLevel.warning,
       );
+      if (_cacheBox != null && _cacheBox!.isOpen) {
+        try {
+          await _cacheBox!.close();
+        } on Object catch (_) {}
+      }
       await _safeDeleteBox(_kBoxName, hivePath);
       _cacheBox = await _hive.openLazyBox<Map>(_kBoxName, path: hivePath);
 
@@ -462,7 +473,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     await file.writeAsBytes(fileBytes);
 
     final validTill = DateTime.now().add(maxAge);
-    _cacheBox!.put(
+    await _cacheBox!.put(
         _sanitizeBoxKey(key),
         CacheEntryMetadata(
           url: url,


### PR DESCRIPTION
## Description

Hive_CE & Hive load the contents of a box into memory alongside the keys, Lazybox loads the keys but only retrieves the value when requested. This reduces memory usage however will add additional latency for cache reads as the value has to be read from disk.

## Related Issues

https://github.com/Erengun/flutter_cached_network_image_ce/issues/30

## Checklist

- [x] I've read the [Contributor Guide]
- [ ] All existing tests pass
- [ ] I've added new tests for any new features or bug fixes
- [ ] I've updated the CHANGELOG if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache metadata validation to detect and surface type decoding and corruption errors immediately during initialization and recovery operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->