### PR TITLE
feat(cache): add LRU cleanup support to DefaultCacheManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,24 @@ Available hooks:
 
 > `CacheInterceptor` is not available on web targets.
 
+### Cache Cleanup Strategy
+
+Control which entries are evicted first when the cache exceeds `maxNrOfCacheObjects`:
+
+```dart
+final manager = DefaultCacheManager(
+  maxNrOfCacheObjects: 200,
+  cleanupStrategy: const LruCleanupStrategy(),
+);
+```
+
+| Strategy | Eviction order | Default |
+| :--- | :--- | :--- |
+| `TtlCleanupStrategy` | Soonest-to-expire (`validTill`) first | ✅ |
+| `LruCleanupStrategy` | Least-recently-used (`touchedAt`) first | |
+
+`LruCleanupStrategy` relies on `touchedAt`, which is updated on every cache hit. Legacy entries written before this field existed fall back to `validTill` ordering. Implement `CleanupStrategy` for a custom eviction policy.
+
 ## ❓ FAQ
 
 **Q: Will I lose my users' existing cache if I migrate?**

--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.8.0] - 2026-06-16
+
+* **Feature:** Added LRU cache cleanup support to `DefaultCacheManager`.
+  * New `CleanupStrategy` abstraction controls eviction order when the cache exceeds `maxNrOfCacheObjects`.
+  * `TtlCleanupStrategy` — evicts soonest-to-expire entries first. Matches prior behaviour and remains the default.
+  * `LruCleanupStrategy` — evicts least-recently-used entries first, based on a new `touchedAt` timestamp updated on every cache hit.
+  * `CacheEntryMetadata` gains a nullable `touchedAt` field; legacy entries without it fall back to `validTill` via `effectiveTouchedAt`.
+  * Pass a strategy via the new `cleanupStrategy` parameter on `DefaultCacheManager`, or implement `CleanupStrategy` for a custom eviction policy.
+
 ## [4.7.0] - 2026-06-10
 
 * **Feature:** Added HTTP and cache interceptor support to `DefaultCacheManager`.

--- a/cached_network_image/lib/cached_network_image.dart
+++ b/cached_network_image/lib/cached_network_image.dart
@@ -17,6 +17,7 @@ export 'package:cached_network_image_platform_interface_ce/cached_network_image_
         ImageFormatDetector,
         UnsupportedImageFormatException;
 
+export 'src/cache/cleanup_strategy.dart';
 export 'src/cache/default_cache_manager_factory.dart';
 export 'src/cache/interceptors/cache_interceptor.dart'
     if (dart.library.js_interop) 'src/cache/interceptors/cache_interceptor_stub.dart';

--- a/cached_network_image/lib/src/cache/cache_entry_metadata.dart
+++ b/cached_network_image/lib/src/cache/cache_entry_metadata.dart
@@ -6,16 +6,21 @@ class CacheEntryMetadata {
     required this.validTill,
     this.eTag,
     this.length = 0,
+    this.touchedAt,
   });
 
   /// Reconstructs a [CacheEntryMetadata] from a Hive-stored [Map].
   factory CacheEntryMetadata.fromMap(Map map) {
+    final touchedAtMs = map['touchedAt'] as int?;
     return CacheEntryMetadata(
       url: map['url'] as String,
       relativePath: map['relativePath'] as String,
       validTill: DateTime.fromMillisecondsSinceEpoch(map['validTill'] as int),
       eTag: map['eTag'] as String?,
       length: (map['length'] as int?) ?? 0,
+      touchedAt: touchedAtMs != null
+          ? DateTime.fromMillisecondsSinceEpoch(touchedAtMs)
+          : null,
     );
   }
 
@@ -34,6 +39,14 @@ class CacheEntryMetadata {
   /// The size of the cached file in bytes.
   final int length;
 
+  /// When this entry was last written or explicitly accessed.
+  ///
+  /// Null for entries created before this field was introduced.
+  final DateTime? touchedAt;
+
+  /// Returns [touchedAt] if set, otherwise falls back to [validTill].
+  DateTime get effectiveTouchedAt => touchedAt ?? validTill;
+
   /// Serializes this metadata to a [Map] for Hive storage.
   Map<String, dynamic> toMap() {
     return {
@@ -42,6 +55,7 @@ class CacheEntryMetadata {
       'validTill': validTill.millisecondsSinceEpoch,
       'eTag': eTag,
       'length': length,
+      if (touchedAt != null) 'touchedAt': touchedAt!.millisecondsSinceEpoch,
     };
   }
 }

--- a/cached_network_image/lib/src/cache/cache_entry_metadata.dart
+++ b/cached_network_image/lib/src/cache/cache_entry_metadata.dart
@@ -1,5 +1,5 @@
 /// Typed metadata for a cached file entry, stored in Hive.
-class CacheEntryMetadata {
+final class CacheEntryMetadata {
   CacheEntryMetadata({
     required this.url,
     required this.relativePath,

--- a/cached_network_image/lib/src/cache/cleanup_strategy.dart
+++ b/cached_network_image/lib/src/cache/cleanup_strategy.dart
@@ -1,0 +1,47 @@
+import 'cache_entry_metadata.dart';
+
+/// Defines the order in which cache entries are evicted when the cache
+/// exceeds [DefaultCacheManager.maxNrOfCacheObjects].
+///
+/// Implement this class to provide a custom eviction policy. The first
+/// entries in the returned list will be evicted first.
+abstract class CleanupStrategy {
+  /// Sorts [entries] so that the entries to evict first appear at the
+  /// beginning of the returned list.
+  List<MapEntry<String, CacheEntryMetadata>> sortForEviction(
+    List<MapEntry<String, CacheEntryMetadata>> entries,
+  );
+}
+
+/// Evicts entries with the earliest expiry date first (TTL-based).
+///
+/// This matches the original [DefaultCacheManager] behaviour and is the
+/// default strategy when no [CleanupStrategy] is provided.
+class TtlCleanupStrategy extends CleanupStrategy {
+  @override
+  List<MapEntry<String, CacheEntryMetadata>> sortForEviction(
+    List<MapEntry<String, CacheEntryMetadata>> entries,
+  ) {
+    return entries
+      ..sort((a, b) => a.value.validTill.compareTo(b.value.validTill));
+  }
+}
+
+/// Evicts least-recently-used entries first (LRU-based).
+///
+/// Uses [CacheEntryMetadata.effectiveTouchedAt] as the access timestamp,
+/// which falls back to [CacheEntryMetadata.validTill] for legacy entries
+/// that pre-date the [touchedAt] field.
+class LruCleanupStrategy extends CleanupStrategy {
+  @override
+  List<MapEntry<String, CacheEntryMetadata>> sortForEviction(
+    List<MapEntry<String, CacheEntryMetadata>> entries,
+  ) {
+    return entries
+      ..sort(
+        (a, b) => a.value.effectiveTouchedAt.compareTo(
+          b.value.effectiveTouchedAt,
+        ),
+      );
+  }
+}

--- a/cached_network_image/lib/src/cache/cleanup_strategy.dart
+++ b/cached_network_image/lib/src/cache/cleanup_strategy.dart
@@ -6,8 +6,14 @@ import 'cache_entry_metadata.dart';
 /// Implement this class to provide a custom eviction policy. The first
 /// entries in the returned list will be evicted first.
 abstract class CleanupStrategy {
+  const CleanupStrategy();
+
   /// Sorts [entries] so that the entries to evict first appear at the
   /// beginning of the returned list.
+  ///
+  /// Implementations may sort [entries] in-place and return the same list,
+  /// or return a new sorted list. The caller uses the returned list to
+  /// determine eviction order.
   List<MapEntry<String, CacheEntryMetadata>> sortForEviction(
     List<MapEntry<String, CacheEntryMetadata>> entries,
   );
@@ -17,7 +23,9 @@ abstract class CleanupStrategy {
 ///
 /// This matches the original [DefaultCacheManager] behaviour and is the
 /// default strategy when no [CleanupStrategy] is provided.
-class TtlCleanupStrategy extends CleanupStrategy {
+final class TtlCleanupStrategy extends CleanupStrategy {
+  const TtlCleanupStrategy();
+
   @override
   List<MapEntry<String, CacheEntryMetadata>> sortForEviction(
     List<MapEntry<String, CacheEntryMetadata>> entries,
@@ -32,7 +40,9 @@ class TtlCleanupStrategy extends CleanupStrategy {
 /// Uses [CacheEntryMetadata.effectiveTouchedAt] as the access timestamp,
 /// which falls back to [CacheEntryMetadata.validTill] for legacy entries
 /// that pre-date the [touchedAt] field.
-class LruCleanupStrategy extends CleanupStrategy {
+final class LruCleanupStrategy extends CleanupStrategy {
+  const LruCleanupStrategy();
+
   @override
   List<MapEntry<String, CacheEntryMetadata>> sortForEviction(
     List<MapEntry<String, CacheEntryMetadata>> entries,

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -551,6 +551,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   ///
   /// Fire-and-forget — callers should wrap with [unawaited].
   Future<void> _touchEntry(String key, CacheEntryMetadata metadata) async {
+    // Capture _cacheBox before the first await to guard against a concurrent
+    // dispose() nulling the field while this future is suspended.
+    final box = _cacheBox;
+    if (box == null || !box.isOpen) return;
     final updated = CacheEntryMetadata(
       url: metadata.url,
       relativePath: metadata.relativePath,
@@ -559,7 +563,14 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       length: metadata.length,
       touchedAt: DateTime.now(),
     );
-    await _cacheBox!.put(_sanitizeBoxKey(key), updated.toMap());
+    try {
+      await box.put(_sanitizeBoxKey(key), updated.toMap());
+    } on Object catch (e) {
+      cacheLogger.log(
+        'CacheManager: Failed to update touchedAt for $key: $e',
+        CacheManagerLogLevel.debug,
+      );
+    }
   }
 
   @override

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -548,29 +548,36 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     }
 
     final localFile = const LocalFileSystem().file(filePath);
-    unawaited(_touchEntry(key, metadata));
+    unawaited(_touchEntry(key));
     return FileInfo(
         localFile, FileSource.Cache, metadata.validTill, metadata.url);
   }
 
   /// Updates the [touchedAt] timestamp for [key] in the cache box.
   ///
-  /// Fire-and-forget — callers should wrap with [unawaited].
-  Future<void> _touchEntry(String key, CacheEntryMetadata metadata) async {
+  /// Re-reads the current entry immediately before writing so a concurrent
+  /// update to other fields (e.g. a re-download) isn't clobbered by a touch
+  /// based on stale metadata. Fire-and-forget — callers should wrap with
+  /// [unawaited].
+  Future<void> _touchEntry(String key) async {
     // Capture _cacheBox before the first await to guard against a concurrent
     // dispose() nulling the field while this future is suspended.
     final box = _cacheBox;
     if (box == null || !box.isOpen) return;
-    final updated = CacheEntryMetadata(
-      url: metadata.url,
-      relativePath: metadata.relativePath,
-      validTill: metadata.validTill,
-      eTag: metadata.eTag,
-      length: metadata.length,
-      touchedAt: DateTime.now(),
-    );
+    final sanitizedKey = _sanitizeBoxKey(key);
     try {
-      await box.put(_sanitizeBoxKey(key), updated.toMap());
+      final raw = box.get(sanitizedKey);
+      if (raw == null) return;
+      final current = CacheEntryMetadata.fromMap(raw);
+      final updated = CacheEntryMetadata(
+        url: current.url,
+        relativePath: current.relativePath,
+        validTill: current.validTill,
+        eTag: current.eTag,
+        length: current.length,
+        touchedAt: DateTime.now(),
+      );
+      await box.put(sanitizedKey, updated.toMap());
     } on Object catch (e) {
       cacheLogger.log(
         'CacheManager: Failed to update touchedAt for $key: $e',

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -17,6 +17,7 @@ import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
 import 'cache_entry_metadata.dart';
+import 'cleanup_strategy.dart';
 import 'interceptors/cache_interceptor.dart';
 import 'interceptors/http_interceptor.dart';
 import 'interceptors/interceptor_runner.dart';
@@ -63,11 +64,13 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     CacheDirectoryProvider? cacheDirectoryProvider,
     List<HttpInterceptor> httpInterceptors = const [],
     List<CacheInterceptor> cacheInterceptors = const [],
+    CleanupStrategy? cleanupStrategy,
   })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
         _cacheDirectoryProvider =
             cacheDirectoryProvider ?? getTemporaryDirectory,
         _httpInterceptors = httpInterceptors,
-        _cacheInterceptors = cacheInterceptors;
+        _cacheInterceptors = cacheInterceptors,
+        _cleanupStrategy = cleanupStrategy ?? TtlCleanupStrategy();
 
   /// Duration before cached files are considered stale.
   final Duration stalePeriod;
@@ -92,6 +95,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
   /// Cache interceptors that run on hit, miss, and store events.
   final List<CacheInterceptor> _cacheInterceptors;
+
+  /// Strategy that determines the eviction order when the cache is over capacity.
+  final CleanupStrategy _cleanupStrategy;
 
   /// Private Hive instance to avoid conflicts with the host app's global
   /// [Hive] singleton. Each [DefaultCacheManager] gets its own isolated
@@ -676,12 +682,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   Future<void> _cleanupOldFiles() async {
     try {
       final now = DateTime.now();
-      final entries = <MapEntry<dynamic, CacheEntryMetadata>>[];
+      final entries = <MapEntry<String, CacheEntryMetadata>>[];
 
       for (final key in _cacheBox!.keys.toList()) {
         final raw = _cacheBox!.get(key);
         if (raw != null) {
-          entries.add(MapEntry(key, CacheEntryMetadata.fromMap(raw)));
+          entries.add(MapEntry(key as String, CacheEntryMetadata.fromMap(raw)));
         }
       }
 
@@ -698,10 +704,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
       // If cache is still too large, remove oldest entries
       if (_cacheBox!.length > maxNrOfCacheObjects) {
-        final sortedEntries = entries
-            .where((e) => _cacheBox!.containsKey(e.key))
-            .toList()
-          ..sort((a, b) => a.value.validTill.compareTo(b.value.validTill));
+        final sortedEntries = _cleanupStrategy.sortForEviction(
+          entries.where((e) => _cacheBox!.containsKey(e.key)).toList(),
+        );
 
         final toRemove = sortedEntries.length - maxNrOfCacheObjects;
         for (var i = 0; i < toRemove; i++) {

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -490,6 +490,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       validTill: validTill,
       eTag: eTag,
       length: receivedBytes,
+      touchedAt: DateTime.now(),
     );
     final storeOutcome = await runOnStoreChain(
       _cacheInterceptors,
@@ -574,6 +575,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
           validTill: validTill,
           eTag: eTag,
           length: fileBytes.length,
+          touchedAt: DateTime.now(),
         ).toMap());
 
     return const LocalFileSystem().file(filePath);

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -542,8 +542,24 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     }
 
     final localFile = const LocalFileSystem().file(filePath);
+    unawaited(_touchEntry(key, metadata));
     return FileInfo(
         localFile, FileSource.Cache, metadata.validTill, metadata.url);
+  }
+
+  /// Updates the [touchedAt] timestamp for [key] in the cache box.
+  ///
+  /// Fire-and-forget — callers should wrap with [unawaited].
+  Future<void> _touchEntry(String key, CacheEntryMetadata metadata) async {
+    final updated = CacheEntryMetadata(
+      url: metadata.url,
+      relativePath: metadata.relativePath,
+      validTill: metadata.validTill,
+      eTag: metadata.eTag,
+      length: metadata.length,
+      touchedAt: DateTime.now(),
+    );
+    await _cacheBox!.put(_sanitizeBoxKey(key), updated.toMap());
   }
 
   @override

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -70,7 +70,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
             cacheDirectoryProvider ?? getTemporaryDirectory,
         _httpInterceptors = httpInterceptors,
         _cacheInterceptors = cacheInterceptors,
-        _cleanupStrategy = cleanupStrategy ?? TtlCleanupStrategy();
+        _cleanupStrategy = cleanupStrategy ?? const TtlCleanupStrategy();
 
   /// Duration before cached files are considered stale.
   final Duration stalePeriod;

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.7.0
+version: 4.8.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/cache_entry_metadata_test.dart
+++ b/cached_network_image/test/cache_entry_metadata_test.dart
@@ -2,6 +2,92 @@ import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('CacheEntryMetadata touchedAt', () {
+    test('toMap includes touchedAt when set', () {
+      final validTill = DateTime(2025, 6, 15);
+      final touchedAt = DateTime(2025, 6, 10, 12, 0, 0);
+      final metadata = CacheEntryMetadata(
+        url: 'https://example.com/image.png',
+        relativePath: 'abc.png',
+        validTill: validTill,
+        touchedAt: touchedAt,
+      );
+
+      final map = metadata.toMap();
+      expect(map.containsKey('touchedAt'), isTrue);
+      expect(map['touchedAt'], touchedAt.millisecondsSinceEpoch);
+    });
+
+    test('toMap omits touchedAt key when null', () {
+      final metadata = CacheEntryMetadata(
+        url: 'https://example.com/image.png',
+        relativePath: 'abc.png',
+        validTill: DateTime(2025, 6, 15),
+      );
+
+      final map = metadata.toMap();
+      expect(map.containsKey('touchedAt'), isFalse);
+    });
+
+    test('toMap/fromMap roundtrip preserves touchedAt', () {
+      final validTill = DateTime(2025, 6, 15);
+      final touchedAt = DateTime(2025, 6, 10, 8, 30, 0);
+      final original = CacheEntryMetadata(
+        url: 'https://example.com/roundtrip.png',
+        relativePath: 'rt.png',
+        validTill: validTill,
+        touchedAt: touchedAt,
+      );
+
+      final reconstructed = CacheEntryMetadata.fromMap(original.toMap());
+
+      expect(
+        reconstructed.touchedAt!.millisecondsSinceEpoch,
+        touchedAt.millisecondsSinceEpoch,
+      );
+    });
+
+    test('fromMap returns null touchedAt for legacy data without touchedAt key',
+        () {
+      final map = {
+        'url': 'https://example.com/legacy.png',
+        'relativePath': 'legacy.png',
+        'validTill': DateTime(2025, 6, 15).millisecondsSinceEpoch,
+        'eTag': null,
+        'length': 0,
+        // no 'touchedAt' key — legacy entry
+      };
+
+      final metadata = CacheEntryMetadata.fromMap(map);
+      expect(metadata.touchedAt, isNull);
+    });
+
+    test('effectiveTouchedAt returns touchedAt when set', () {
+      final validTill = DateTime(2025, 6, 15);
+      final touchedAt = DateTime(2025, 6, 10);
+      final metadata = CacheEntryMetadata(
+        url: 'https://example.com/image.png',
+        relativePath: 'abc.png',
+        validTill: validTill,
+        touchedAt: touchedAt,
+      );
+
+      expect(metadata.effectiveTouchedAt, touchedAt);
+    });
+
+    test('effectiveTouchedAt falls back to validTill when touchedAt is null',
+        () {
+      final validTill = DateTime(2025, 6, 15);
+      final metadata = CacheEntryMetadata(
+        url: 'https://example.com/image.png',
+        relativePath: 'abc.png',
+        validTill: validTill,
+      );
+
+      expect(metadata.effectiveTouchedAt, validTill);
+    });
+  });
+
   group('CacheEntryMetadata', () {
     test('constructor sets all fields', () {
       final validTill = DateTime(2025, 1, 1);

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io' as io;
 
+import 'package:cached_network_image_ce/cached_network_image.dart'
+    show LruCleanupStrategy, TtlCleanupStrategy;
 import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
 import 'package:flutter/services.dart';
@@ -1736,6 +1738,324 @@ void main() {
       await manager.removeFile(longKey);
       final cachedAfterRemove = await manager.getFileFromCache(longKey);
       expect(cachedAfterRemove, isNull);
+
+      await manager.emptyCache();
+      await manager.dispose();
+    });
+  });
+
+  // ---- touchedAt field behavior ----
+
+  group('DefaultCacheManager touchedAt', () {
+    test('putFile creates entry with non-null touchedAt', () async {
+      final dir = io.Directory.systemTemp.createTempSync('touched_put_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+      );
+      const url = 'https://example.com/touch-put.bin';
+      await manager.putFile(url, [1, 2, 3], fileExtension: 'bin');
+      await manager.dispose();
+
+      // Read raw Hive entry to inspect touchedAt
+      final hivePath = '${dir.path}/cached_network_image_ce/hive';
+      final hive = HiveImpl();
+      final box =
+          await hive.openBox<Map>('cached_network_image_cache', path: hivePath);
+      final raw = box.get(url) as Map?;
+      await box.close();
+      await hive.close();
+
+      expect(raw, isNotNull);
+      expect(raw!['touchedAt'], isNotNull);
+    });
+
+    test('getFileFromCache updates touchedAt to a more recent time', () async {
+      final dir = io.Directory.systemTemp.createTempSync('touched_get_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+      );
+      const url = 'https://example.com/touch-get.bin';
+      await manager.putFile(url, [1, 2, 3], fileExtension: 'bin');
+      await manager.dispose();
+
+      // Read initial touchedAt
+      final hivePath = '${dir.path}/cached_network_image_ce/hive';
+      final hive1 = HiveImpl();
+      final box1 = await hive1.openBox<Map>(
+        'cached_network_image_cache',
+        path: hivePath,
+      );
+      final raw1 = box1.get(url) as Map?;
+      final t0 = raw1!['touchedAt'] as int;
+      await box1.close();
+      await hive1.close();
+
+      // Wait to ensure time advances
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Access the file — triggers unawaited _touchEntry
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+      );
+      await manager2.getFileFromCache(url);
+      // Pump the event loop to let the fire-and-forget write complete
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await manager2.dispose();
+
+      // Read updated touchedAt
+      final hive2 = HiveImpl();
+      final box2 = await hive2.openBox<Map>(
+        'cached_network_image_cache',
+        path: hivePath,
+      );
+      final raw2 = box2.get(url) as Map?;
+      final t1 = raw2!['touchedAt'] as int;
+      await box2.close();
+      await hive2.close();
+
+      expect(t1, greaterThan(t0));
+    });
+  });
+
+  // ---- LRU / TTL cleanup strategy tests ----
+
+  group('LRU cleanup', () {
+    test('LruCleanupStrategy evicts least-recently-accessed entries', () async {
+      final dir = io.Directory.systemTemp.createTempSync('lru_cleanup_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      // Step 1: Add 5 entries with comfortably-future expiry
+      final manager1 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+        maxNrOfCacheObjects: 2,
+        cleanupStrategy: const LruCleanupStrategy(),
+      );
+      final keys = ['lru-a', 'lru-b', 'lru-c', 'lru-d', 'lru-e'];
+      for (final k in keys) {
+        await manager1.putFile(
+          'https://example.com/$k.bin',
+          [1, 2, 3],
+          key: k,
+          fileExtension: 'bin',
+          maxAge: const Duration(hours: 1),
+        );
+      }
+
+      // Wait to ensure time advances past initial touchedAt values
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // Step 2: Access 'lru-a' and 'lru-c' — update their touchedAt
+      await manager1.getFileFromCache('lru-a');
+      await manager1.getFileFromCache('lru-c');
+
+      // Wait for fire-and-forget _touchEntry writes to complete
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      await manager1.dispose();
+
+      // Step 3: Re-create manager — _doInit triggers _cleanupOldFiles
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+        maxNrOfCacheObjects: 2,
+        cleanupStrategy: const LruCleanupStrategy(),
+      );
+
+      // Trigger init and poll until cleanup reduces to ≤ 2
+      await manager2.getFileFromCache('__trigger__');
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        final remaining = <String>[];
+        for (final k in keys) {
+          if (await manager2.getFileFromCache(k) != null) remaining.add(k);
+        }
+        if (remaining.length <= 2) break;
+      }
+
+      // 'lru-a' and 'lru-c' were accessed last — they must survive
+      expect(await manager2.getFileFromCache('lru-a'), isNotNull,
+          reason: 'lru-a was recently accessed and should survive');
+      expect(await manager2.getFileFromCache('lru-c'), isNotNull,
+          reason: 'lru-c was recently accessed and should survive');
+      // b, d, e were not accessed — they should be evicted
+      expect(await manager2.getFileFromCache('lru-b'), isNull,
+          reason: 'lru-b was not accessed and should be evicted');
+      expect(await manager2.getFileFromCache('lru-d'), isNull,
+          reason: 'lru-d was not accessed and should be evicted');
+      expect(await manager2.getFileFromCache('lru-e'), isNull,
+          reason: 'lru-e was not accessed and should be evicted');
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+
+    test('TtlCleanupStrategy evicts earliest-expiring entries first', () async {
+      final dir = io.Directory.systemTemp.createTempSync('ttl_cleanup_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      // Add 5 entries with different but all-future validTill values.
+      // 'ttl-c' and 'ttl-d' have the longest TTL and should survive.
+      final manager1 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+        maxNrOfCacheObjects: 2,
+        cleanupStrategy: const TtlCleanupStrategy(),
+      );
+
+      final entries = [
+        ('ttl-a', const Duration(minutes: 10)),
+        ('ttl-b', const Duration(minutes: 20)),
+        ('ttl-c', const Duration(hours: 10)),
+        ('ttl-d', const Duration(hours: 20)),
+        ('ttl-e', const Duration(minutes: 30)),
+      ];
+      for (final (k, age) in entries) {
+        await manager1.putFile(
+          'https://example.com/$k.bin',
+          [1],
+          key: k,
+          fileExtension: 'bin',
+          maxAge: age,
+        );
+      }
+      await manager1.dispose();
+
+      // Re-initialize to trigger cleanup
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+        maxNrOfCacheObjects: 2,
+        cleanupStrategy: const TtlCleanupStrategy(),
+      );
+
+      await manager2.getFileFromCache('__trigger__');
+      // Poll until cleanup completes
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        final count = [
+          for (final (k, _) in entries)
+            if (await manager2.getFileFromCache(k) != null) k,
+        ].length;
+        if (count <= 2) break;
+      }
+
+      // The 2 longest-lived entries survive
+      expect(await manager2.getFileFromCache('ttl-c'), isNotNull,
+          reason: 'ttl-c has 10h TTL and should survive');
+      expect(await manager2.getFileFromCache('ttl-d'), isNotNull,
+          reason: 'ttl-d has 20h TTL and should survive');
+      // The 3 shortest-lived are evicted first
+      expect(await manager2.getFileFromCache('ttl-a'), isNull,
+          reason: 'ttl-a (10m TTL) should be evicted');
+      expect(await manager2.getFileFromCache('ttl-b'), isNull,
+          reason: 'ttl-b (20m TTL) should be evicted');
+      expect(await manager2.getFileFromCache('ttl-e'), isNull,
+          reason: 'ttl-e (30m TTL) should be evicted');
+
+      await manager2.emptyCache();
+      await manager2.dispose();
+    });
+
+    test('LRU cleanup falls back to validTill ordering for legacy null-touchedAt entries',
+        () async {
+      final dir = io.Directory.systemTemp.createTempSync('lru_legacy_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final hivePath = '${dir.path}/cached_network_image_ce/hive';
+      final cacheFileDir = '${dir.path}/cached_network_image_ce';
+
+      // Create cache directory structure
+      await io.Directory(hivePath).create(recursive: true);
+
+      // Inject legacy entries (no touchedAt) directly into Hive.
+      // We use different validTill so the fallback ordering is deterministic.
+      // Keys are short (<255) so _sanitizeBoxKey is a no-op.
+      final legacyEntries = [
+        ('leg-a', DateTime.now().add(const Duration(minutes: 10))),
+        ('leg-b', DateTime.now().add(const Duration(minutes: 20))),
+        ('leg-c', DateTime.now().add(const Duration(hours: 1))),
+        ('leg-d', DateTime.now().add(const Duration(hours: 2))),
+        ('leg-e', DateTime.now().add(const Duration(hours: 3))),
+      ];
+
+      final injectionHive = HiveImpl();
+      final injectionBox = await injectionHive.openBox<Map>(
+        'cached_network_image_cache',
+        path: hivePath,
+      );
+
+      for (final (k, validTill) in legacyEntries) {
+        // Build map without touchedAt (legacy entry)
+        final meta = CacheEntryMetadata(
+          url: 'https://example.com/$k.bin',
+          relativePath: '$k.bin',
+          validTill: validTill,
+        );
+        final map = meta.toMap(); // touchedAt is null so it's omitted
+        await injectionBox.put(k, map);
+
+        // Create a real file on disk so getFileFromCache doesn't report it missing
+        final file = io.File('$cacheFileDir/$k.bin');
+        await file.create(recursive: true);
+        await file.writeAsBytes([1, 2, 3]);
+      }
+
+      await injectionBox.close();
+      await injectionHive.close();
+
+      // Open manager with LRU strategy and maxNrOfCacheObjects: 2
+      // LRU falls back to effectiveTouchedAt = validTill for null-touchedAt entries
+      // so it behaves like TTL: shortest validTill evicted first.
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => dir,
+        maxNrOfCacheObjects: 2,
+        cleanupStrategy: const LruCleanupStrategy(),
+      );
+
+      await manager.getFileFromCache('__trigger__');
+      // Poll until cleanup completes
+      for (var i = 0; i < 50; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        final count = [
+          for (final (k, _) in legacyEntries)
+            if (await manager.getFileFromCache(k) != null) k,
+        ].length;
+        if (count <= 2) break;
+      }
+
+      // Longest validTill (leg-d, leg-e) survive since effectiveTouchedAt = validTill
+      expect(await manager.getFileFromCache('leg-d'), isNotNull,
+          reason: 'leg-d (2h validTill) should survive as most recently "touched"');
+      expect(await manager.getFileFromCache('leg-e'), isNotNull,
+          reason: 'leg-e (3h validTill) should survive as most recently "touched"');
+      // Shortest validTill entries are evicted
+      expect(await manager.getFileFromCache('leg-a'), isNull,
+          reason: 'leg-a (10m validTill) should be evicted first');
+      expect(await manager.getFileFromCache('leg-b'), isNull,
+          reason: 'leg-b (20m validTill) should be evicted');
+      expect(await manager.getFileFromCache('leg-c'), isNull,
+          reason: 'leg-c (1h validTill) should be evicted');
 
       await manager.emptyCache();
       await manager.dispose();

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1973,7 +1973,8 @@ void main() {
       await manager2.dispose();
     });
 
-    test('LRU cleanup falls back to validTill ordering for legacy null-touchedAt entries',
+    test(
+        'LRU cleanup falls back to validTill ordering for legacy null-touchedAt entries',
         () async {
       final dir = io.Directory.systemTemp.createTempSync('lru_legacy_');
       addTearDown(() {
@@ -2046,9 +2047,11 @@ void main() {
 
       // Longest validTill (leg-d, leg-e) survive since effectiveTouchedAt = validTill
       expect(await manager.getFileFromCache('leg-d'), isNotNull,
-          reason: 'leg-d (2h validTill) should survive as most recently "touched"');
+          reason:
+              'leg-d (2h validTill) should survive as most recently "touched"');
       expect(await manager.getFileFromCache('leg-e'), isNotNull,
-          reason: 'leg-e (3h validTill) should survive as most recently "touched"');
+          reason:
+              'leg-e (3h validTill) should survive as most recently "touched"');
       // Shortest validTill entries are evicted
       expect(await manager.getFileFromCache('leg-a'), isNull,
           reason: 'leg-a (10m validTill) should be evicted first');

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1832,6 +1832,19 @@ void main() {
   // ---- LRU / TTL cleanup strategy tests ----
 
   group('LRU cleanup', () {
+    // Counts cached `.bin` files on disk without going through
+    // getFileFromCache, which would touch entries and disturb the eviction
+    // order being tested.
+    Future<int> countCachedFiles(io.Directory dir) async {
+      final cacheFileDir = io.Directory('${dir.path}/cached_network_image_ce');
+      if (!await cacheFileDir.exists()) return 0;
+      final entries = await cacheFileDir.list().toList();
+      return entries
+          .whereType<io.File>()
+          .where((f) => f.path.endsWith('.bin'))
+          .length;
+    }
+
     test('LruCleanupStrategy evicts least-recently-accessed entries', () async {
       final dir = io.Directory.systemTemp.createTempSync('lru_cleanup_');
       addTearDown(() {
@@ -1876,15 +1889,12 @@ void main() {
         cleanupStrategy: const LruCleanupStrategy(),
       );
 
-      // Trigger init and poll until cleanup reduces to ≤ 2
+      // Trigger init, then poll the filesystem (not getFileFromCache, which
+      // would touch entries) until cleanup reduces the file count to ≤ 2.
       await manager2.getFileFromCache('__trigger__');
       for (var i = 0; i < 50; i++) {
         await Future<void>.delayed(const Duration(milliseconds: 20));
-        final remaining = <String>[];
-        for (final k in keys) {
-          if (await manager2.getFileFromCache(k) != null) remaining.add(k);
-        }
-        if (remaining.length <= 2) break;
+        if (await countCachedFiles(dir) <= 2) break;
       }
 
       // 'lru-a' and 'lru-c' were accessed last — they must survive
@@ -1946,14 +1956,10 @@ void main() {
       );
 
       await manager2.getFileFromCache('__trigger__');
-      // Poll until cleanup completes
+      // Poll the filesystem (not getFileFromCache) until cleanup completes
       for (var i = 0; i < 50; i++) {
         await Future<void>.delayed(const Duration(milliseconds: 20));
-        final count = [
-          for (final (k, _) in entries)
-            if (await manager2.getFileFromCache(k) != null) k,
-        ].length;
-        if (count <= 2) break;
+        if (await countCachedFiles(dir) <= 2) break;
       }
 
       // The 2 longest-lived entries survive
@@ -2035,14 +2041,10 @@ void main() {
       );
 
       await manager.getFileFromCache('__trigger__');
-      // Poll until cleanup completes
+      // Poll the filesystem (not getFileFromCache) until cleanup completes
       for (var i = 0; i < 50; i++) {
         await Future<void>.delayed(const Duration(milliseconds: 20));
-        final count = [
-          for (final (k, _) in legacyEntries)
-            if (await manager.getFileFromCache(k) != null) k,
-        ].length;
-        if (count <= 2) break;
+        if (await countCachedFiles(dir) <= 2) break;
       }
 
       // Longest validTill (leg-d, leg-e) survive since effectiveTouchedAt = validTill

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1767,7 +1767,7 @@ void main() {
       final hive = HiveImpl();
       final box =
           await hive.openBox<Map>('cached_network_image_cache', path: hivePath);
-      final raw = box.get(url) as Map?;
+      final raw = box.get(url);
       await box.close();
       await hive.close();
 
@@ -1797,7 +1797,7 @@ void main() {
         'cached_network_image_cache',
         path: hivePath,
       );
-      final raw1 = box1.get(url) as Map?;
+      final raw1 = box1.get(url);
       final t0 = raw1!['touchedAt'] as int;
       await box1.close();
       await hive1.close();
@@ -1820,7 +1820,7 @@ void main() {
         'cached_network_image_cache',
         path: hivePath,
       );
-      final raw2 = box2.get(url) as Map?;
+      final raw2 = box2.get(url);
       final t1 = raw2!['touchedAt'] as int;
       await box2.close();
       await hive2.close();


### PR DESCRIPTION
## Summary
- Adds a nullable `touchedAt` timestamp to `CacheEntryMetadata`, updated on every cache hit (fire-and-forget) and on new entry creation
- Introduces a pluggable `CleanupStrategy` abstraction with `TtlCleanupStrategy` (existing behavior, default) and `LruCleanupStrategy` (evicts least-recently-used first via `effectiveTouchedAt`)
- `DefaultCacheManager` accepts an optional `cleanupStrategy` parameter; defaults to `TtlCleanupStrategy()` for full backward compatibility

## Why
Resolves the eviction-behavior blocker preventing apps with many generated image variants from adopting `DefaultCacheManager` in place of a custom cache — they can now opt into LRU eviction ordering via `cleanupStrategy: const LruCleanupStrategy()`.

## Test plan
- [x] `dart analyze` clean across `lib` and `test`
- [x] 80/80 tests pass, including new coverage:
  - `touchedAt` serialization roundtrip, legacy (null) backward compatibility, `effectiveTouchedAt` fallback
  - `putFile` initializes `touchedAt`
  - `getFileFromCache` updates `touchedAt` on hit
  - `LruCleanupStrategy` evicts least-recently-accessed entries under capacity pressure
  - `TtlCleanupStrategy` preserves original earliest-expiry eviction order
  - LRU cleanup falls back to `validTill` ordering for legacy entries with no `touchedAt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cache cleanup strategies with least-recently-used (LRU) and time-to-live (TTL) based eviction options.
  * Implemented automatic access-time tracking for cached files to support smarter cache management policies.
  * Made cleanup strategy extensibility available as part of the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->