### PR TITLE
feat: allow separate metadata cache directory

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.9.0] - 2026-06-17
+
+* **Feature:** Added `metadataDirectoryProvider` to `DefaultCacheManager` so Hive metadata can be stored separately from cached image files on IO platforms.
+
 ## [4.8.0] - 2026-06-16
 
 * **Feature:** Added LRU cache cleanup support to `DefaultCacheManager`.

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -145,6 +145,26 @@ On Flutter Web, timeout settings apply when using
 `ImageRenderMethodForWeb.HttpGet`. The `HtmlImage` render method uses the
 browser image pipeline and bypasses the cache manager HTTP path.
 
+### Cache and Metadata Directories
+
+On native IO targets, cached image files and Hive metadata can use separate
+base directories.
+
+```dart
+final cacheManager = DefaultCacheManager(
+  cacheDirectoryProvider: getTemporaryDirectory,
+  metadataDirectoryProvider: getApplicationSupportDirectory,
+);
+```
+
+If `metadataDirectoryProvider` is omitted, metadata stays under the cache
+directory:
+
+```text
+<cacheBase>/cached_network_image_ce/
+<cacheBase>/cached_network_image_ce/hive/
+```
+
 **Web Platform Headers Support:** Custom headers (like `Authorization`) are
 **only supported with `ImageRenderMethodForWeb.HttpGet`**. The default
 `HtmlImage` render method does not support custom headers. If you need to

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -119,6 +119,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// loading at the same time on cold start) share the same init future.
   Completer<void>? _initCompleter;
 
+  /// Handle to the background cleanup sweep launched by [_doInit], so
+  /// [dispose] can wait for it instead of racing it.
+  Future<void>? _cleanupFuture;
+
   /// Initialize Hive and open the cache metadata box.
   ///
   /// Uses a [Completer] to ensure that only one initialization runs at a
@@ -150,11 +154,27 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
   Future<void> _doInit() async {
     final dir = await _cacheDirectoryProvider();
-    _cacheDir = path.join(dir.path, 'cached_network_image_ce');
+    final metadataDir = _metadataDirectoryProvider == null
+        ? dir
+        : await _metadataDirectoryProvider!();
+
+    // When a distinct metadataDirectoryProvider is configured, namespace the
+    // cache file directory by that location. Otherwise two DefaultCacheManager
+    // instances could share the same cacheDirectoryProvider while keeping
+    // separate, unaware-of-each-other Hive boxes — each instance's orphan
+    // sweep would then see the other's files as unknown and delete them.
+    final cacheSubDir = _metadataDirectoryProvider == null
+        ? 'cached_network_image_ce'
+        : path.join(
+            'cached_network_image_ce',
+            sha256
+                .convert(utf8.encode(metadataDir.path))
+                .toString()
+                .substring(0, 16),
+          );
+    _cacheDir = path.join(dir.path, cacheSubDir);
     await io.Directory(_cacheDir!).create(recursive: true);
 
-    final metadataDir =
-        await (_metadataDirectoryProvider ?? _cacheDirectoryProvider)();
     final hivePath = path.join(
       metadataDir.path,
       'cached_network_image_ce',
@@ -182,8 +202,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       await _deleteCacheFiles();
     }
 
-    // Run cleanup in background
-    unawaited(_cleanupOldFiles());
+    // Run cleanup in background, but keep a handle so dispose() can wait
+    // for it instead of nulling fields out from under it mid-sweep.
+    _cleanupFuture = _cleanupOldFiles();
+    unawaited(_cleanupFuture);
   }
 
   /// Attempts to delete a Hive box from disk, tolerating missing files.
@@ -680,6 +702,15 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       }
     }
 
+    final inFlightCleanup = _cleanupFuture;
+    if (inFlightCleanup != null) {
+      try {
+        await inFlightCleanup;
+      } on Object catch (_) {
+        // Already logged inside _cleanupOldFiles; ignore here.
+      }
+    }
+
     if (_cacheBox != null && _cacheBox!.isOpen) {
       try {
         await _cacheBox!.close();
@@ -697,6 +728,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     _cacheBox = null;
     _cacheDir = null;
     _initCompleter = null;
+    _cleanupFuture = null;
   }
 
   /// Clean up files that haven't been used in a while.
@@ -712,17 +744,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         }
       }
 
-      try {
-        await _deleteOrphanedCacheFiles(
-          entries.map((entry) => entry.value.relativePath).toSet(),
-          now,
-        );
-      } on Object catch (e) {
-        cacheLogger.log(
-          'CacheManager: Error during orphaned file cleanup: $e',
-          CacheManagerLogLevel.warning,
-        );
-      }
+      await _deleteOrphanedCacheFiles(
+        entries.map((entry) => entry.value.relativePath).toSet(),
+        now,
+      );
 
       // Remove expired entries
       for (final entry in entries) {
@@ -773,11 +798,15 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       if (knownRelativePaths.contains(relativePath)) continue;
 
       try {
-        final stat = entity.statSync();
+        final stat = await entity.stat();
         if (now.difference(stat.modified) < _kOrphanFileGracePeriod) continue;
         await entity.delete();
-      } on Object {
-        continue;
+      } on Object catch (e) {
+        cacheLogger.log(
+          'CacheManager: Error checking/deleting orphaned file '
+          '${entity.path}: $e',
+          CacheManagerLogLevel.warning,
+        );
       }
     }
   }

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -772,16 +772,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final relativePath = path.relative(entity.path, from: _cacheDir!);
       if (knownRelativePaths.contains(relativePath)) continue;
 
-      io.FileStat stat;
       try {
-        stat = entity.statSync();
-      } on Object {
-        continue;
-      }
-
-      if (now.difference(stat.modified) < _kOrphanFileGracePeriod) continue;
-
-      try {
+        final stat = entity.statSync();
+        if (now.difference(stat.modified) < _kOrphanFileGracePeriod) continue;
         await entity.delete();
       } on Object {
         continue;

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -28,6 +28,7 @@ const _kBoxName = 'cached_network_image_cache';
 const _kDefaultMaxAge = Duration(days: 30);
 const _kDefaultMaxCacheObjects = 200;
 const _kDefaultStalePeriod = Duration(days: 7);
+const _kOrphanFileGracePeriod = Duration(minutes: 5);
 
 const _supportedFileNames = ['jpg', 'jpeg', 'png', 'tga', 'cur', 'ico'];
 
@@ -712,6 +713,11 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         }
       }
 
+      await _deleteOrphanedCacheFiles(
+        entries.map((entry) => entry.value.relativePath).toSet(),
+        now,
+      );
+
       // Remove expired entries
       for (final entry in entries) {
         if (entry.value.validTill.isBefore(now)) {
@@ -744,6 +750,32 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         'CacheManager: Error during cleanup: $e',
         CacheManagerLogLevel.warning,
       );
+    }
+  }
+
+  Future<void> _deleteOrphanedCacheFiles(
+    Set<String> knownRelativePaths,
+    DateTime now,
+  ) async {
+    final cacheDir = io.Directory(_cacheDir!);
+    if (!await cacheDir.exists()) return;
+
+    await for (final entity in cacheDir.list()) {
+      if (entity is! io.File) continue;
+
+      final relativePath = path.relative(entity.path, from: _cacheDir!);
+      if (knownRelativePaths.contains(relativePath)) continue;
+
+      io.FileStat stat;
+      try {
+        stat = entity.statSync();
+      } on Object {
+        continue;
+      }
+
+      if (now.difference(stat.modified) < _kOrphanFileGracePeriod) continue;
+
+      await entity.delete();
     }
   }
 

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -39,7 +39,7 @@ String _sanitizeBoxKey(String key) {
   return '${key.substring(0, 190)}_$hash';
 }
 
-/// Signature for a function that returns the cache base directory.
+/// Signature for a function that returns a cache base directory.
 ///
 /// Defaults to [getTemporaryDirectory] when not specified.
 typedef CacheDirectoryProvider = Future<io.Directory> Function();
@@ -56,18 +56,24 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   ///   Defaults to [getTemporaryDirectory]. Pass [getApplicationSupportDirectory]
   ///   if you need a more persistent location (but note that files may be
   ///   backed up on iOS/Android).
+  /// [metadataDirectoryProvider] allows overriding where Hive metadata is stored.
+  ///   Defaults to [cacheDirectoryProvider] for backwards compatibility.
   DefaultCacheManager({
     this.stalePeriod = _kDefaultStalePeriod,
     this.maxNrOfCacheObjects = _kDefaultMaxCacheObjects,
     this.connectionParameters,
     http.Client Function()? httpClientFactory,
     CacheDirectoryProvider? cacheDirectoryProvider,
+    CacheDirectoryProvider? metadataDirectoryProvider,
     List<HttpInterceptor> httpInterceptors = const [],
     List<CacheInterceptor> cacheInterceptors = const [],
     CleanupStrategy? cleanupStrategy,
   })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
         _cacheDirectoryProvider =
             cacheDirectoryProvider ?? getTemporaryDirectory,
+        _metadataDirectoryProvider = metadataDirectoryProvider ??
+            cacheDirectoryProvider ??
+            getTemporaryDirectory,
         _httpInterceptors = httpInterceptors,
         _cacheInterceptors = cacheInterceptors,
         _cleanupStrategy = cleanupStrategy ?? const TtlCleanupStrategy();
@@ -89,6 +95,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
   /// Provider for the base cache directory.
   final CacheDirectoryProvider _cacheDirectoryProvider;
+
+  /// Provider for the base Hive metadata directory.
+  final CacheDirectoryProvider _metadataDirectoryProvider;
 
   /// HTTP interceptors that run for every download.
   final List<HttpInterceptor> _httpInterceptors;
@@ -145,7 +154,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     _cacheDir = path.join(dir.path, 'cached_network_image_ce');
     await io.Directory(_cacheDir!).create(recursive: true);
 
-    final hivePath = path.join(_cacheDir!, 'hive');
+    final metadataDir = await _metadataDirectoryProvider();
+    final hivePath = path.join(
+      metadataDir.path,
+      'cached_network_image_ce',
+      'hive',
+    );
     await io.Directory(hivePath).create(recursive: true);
 
     // Open the box with an explicit path on the private Hive instance.

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -72,9 +72,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
         _cacheDirectoryProvider =
             cacheDirectoryProvider ?? getTemporaryDirectory,
-        _metadataDirectoryProvider = metadataDirectoryProvider ??
-            cacheDirectoryProvider ??
-            getTemporaryDirectory,
+        _metadataDirectoryProvider = metadataDirectoryProvider,
         _httpInterceptors = httpInterceptors,
         _cacheInterceptors = cacheInterceptors,
         _cleanupStrategy = cleanupStrategy ?? const TtlCleanupStrategy();
@@ -98,7 +96,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   final CacheDirectoryProvider _cacheDirectoryProvider;
 
   /// Provider for the base Hive metadata directory.
-  final CacheDirectoryProvider _metadataDirectoryProvider;
+  final CacheDirectoryProvider? _metadataDirectoryProvider;
 
   /// HTTP interceptors that run for every download.
   final List<HttpInterceptor> _httpInterceptors;
@@ -155,7 +153,8 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     _cacheDir = path.join(dir.path, 'cached_network_image_ce');
     await io.Directory(_cacheDir!).create(recursive: true);
 
-    final metadataDir = await _metadataDirectoryProvider();
+    final metadataDir =
+        await (_metadataDirectoryProvider ?? _cacheDirectoryProvider)();
     final hivePath = path.join(
       metadataDir.path,
       'cached_network_image_ce',

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -712,10 +712,17 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         }
       }
 
-      await _deleteOrphanedCacheFiles(
-        entries.map((entry) => entry.value.relativePath).toSet(),
-        now,
-      );
+      try {
+        await _deleteOrphanedCacheFiles(
+          entries.map((entry) => entry.value.relativePath).toSet(),
+          now,
+        );
+      } on Object catch (e) {
+        cacheLogger.log(
+          'CacheManager: Error during orphaned file cleanup: $e',
+          CacheManagerLogLevel.warning,
+        );
+      }
 
       // Remove expired entries
       for (final entry in entries) {
@@ -774,7 +781,11 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
       if (now.difference(stat.modified) < _kOrphanFileGracePeriod) continue;
 
-      await entity.delete();
+      try {
+        await entity.delete();
+      } on Object {
+        continue;
+      }
     }
   }
 

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -764,6 +764,69 @@ void main() {
       await manager2.dispose();
     });
 
+    test('reconciles orphaned cache files with a grace window', () async {
+      final cacheDir =
+          io.Directory.systemTemp.createTempSync('orphan_file_cache_');
+      final metadataDir =
+          io.Directory.systemTemp.createTempSync('orphan_metadata_');
+      addTearDown(() {
+        try {
+          cacheDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+        try {
+          metadataDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => cacheDir,
+        metadataDirectoryProvider: () async => metadataDir,
+      );
+
+      const oldUrl = 'https://example.com/orphan-old.bin';
+      const recentUrl = 'https://example.com/orphan-recent.bin';
+      await manager.putFile(oldUrl, [1, 2, 3], fileExtension: 'bin');
+      await manager.putFile(recentUrl, [4, 5, 6], fileExtension: 'bin');
+
+      final oldCached = await manager.getFileFromCache(oldUrl);
+      final recentCached = await manager.getFileFromCache(recentUrl);
+      expect(oldCached, isNotNull);
+      expect(recentCached, isNotNull);
+
+      final oldFile = oldCached!.file as io.File;
+      final recentFile = recentCached!.file as io.File;
+      await manager.dispose();
+
+      await oldFile.setLastModified(
+        DateTime.now().subtract(const Duration(minutes: 10)),
+      );
+      await recentFile.setLastModified(DateTime.now());
+
+      final hiveDir =
+          io.Directory('${metadataDir.path}/cached_network_image_ce/hive');
+      if (hiveDir.existsSync()) {
+        hiveDir.deleteSync(recursive: true);
+      }
+
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => cacheDir,
+        metadataDirectoryProvider: () async => metadataDir,
+      );
+
+      expect(await manager2.getFileFromCache(oldUrl), isNull);
+      expect(await manager2.getFileFromCache(recentUrl), isNull);
+
+      for (var i = 0; i < 50; i++) {
+        if (!oldFile.existsSync()) break;
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+
+      expect(oldFile.existsSync(), isFalse);
+      expect(recentFile.existsSync(), isTrue);
+
+      await manager2.dispose();
+    });
+
     test('recovers when cache files are deleted but Hive metadata remains',
         () async {
       final customDir =

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -185,6 +185,47 @@ void main() {
       await box.close();
       await hive.close();
     });
+
+    test(
+        'does not invoke cacheDirectoryProvider twice when '
+        'metadataDirectoryProvider is omitted', () async {
+      final providerDirs = <io.Directory>[
+        io.Directory.systemTemp.createTempSync('double_invoke_a_'),
+        io.Directory.systemTemp.createTempSync('double_invoke_b_'),
+      ];
+      addTearDown(() {
+        for (final dir in providerDirs) {
+          try {
+            dir.deleteSync(recursive: true);
+          } on Object catch (_) {}
+        }
+      });
+
+      var callCount = 0;
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => providerDirs[callCount++],
+      );
+
+      await manager.putFile(
+        'https://example.com/double-invoke.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+
+      expect(
+        callCount,
+        1,
+        reason: 'cacheDirectoryProvider must be resolved once and reused '
+            'for metadata when metadataDirectoryProvider is omitted',
+      );
+
+      final hiveDirOnFirstCall = io.Directory(
+        '${providerDirs[0].path}/cached_network_image_ce/hive',
+      );
+      expect(hiveDirOnFirstCall.existsSync(), isTrue);
+
+      await manager.dispose();
+    });
   });
 
   // ---- Concurrent initialization (race condition regression) ----
@@ -825,6 +866,66 @@ void main() {
       expect(recentFile.existsSync(), isTrue);
 
       await manager2.dispose();
+    });
+
+    test(
+        'orphan sweep from one metadataDirectoryProvider does not delete '
+        'cache files owned by another sharing the same cacheDirectoryProvider',
+        () async {
+      final sharedCacheDir =
+          io.Directory.systemTemp.createTempSync('shared_cache_dir_');
+      final metadataDirA =
+          io.Directory.systemTemp.createTempSync('isolation_metadata_a_');
+      final metadataDirB =
+          io.Directory.systemTemp.createTempSync('isolation_metadata_b_');
+      addTearDown(() {
+        for (final dir in [sharedCacheDir, metadataDirA, metadataDirB]) {
+          try {
+            dir.deleteSync(recursive: true);
+          } on Object catch (_) {}
+        }
+      });
+
+      final managerA = DefaultCacheManager(
+        cacheDirectoryProvider: () async => sharedCacheDir,
+        metadataDirectoryProvider: () async => metadataDirA,
+      );
+      final managerB = DefaultCacheManager(
+        cacheDirectoryProvider: () async => sharedCacheDir,
+        metadataDirectoryProvider: () async => metadataDirB,
+      );
+
+      const bUrl = 'https://example.com/isolation-b-only.bin';
+      await managerB.putFile(bUrl, [4, 5, 6], fileExtension: 'bin');
+      final bCached = await managerB.getFileFromCache(bUrl);
+      expect(bCached, isNotNull);
+      final bFile = bCached!.file as io.File;
+
+      // Make B's file look old enough to be eligible for orphan deletion
+      // by a sweep that has no knowledge of it.
+      await bFile.setLastModified(
+        DateTime.now().subtract(const Duration(minutes: 10)),
+      );
+
+      await managerA.dispose();
+
+      // A fresh manager A instance: same cacheDirectoryProvider as B, but a
+      // different metadataDirectoryProvider. Its cold-start orphan sweep
+      // must not see (and delete) a file it doesn't own.
+      final managerA2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => sharedCacheDir,
+        metadataDirectoryProvider: () async => metadataDirA,
+      );
+      await managerA2.getFileFromCache('trigger-init');
+
+      // Give the sweep time to run; it should find nothing of B's to delete.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(bFile.existsSync(), isTrue);
+      expect(await managerB.getFileFromCache(bUrl), isNotNull);
+
+      await managerA2.dispose();
+      await managerB.dispose();
     });
 
     test('recovers when cache files are deleted but Hive metadata remains',
@@ -1653,6 +1754,56 @@ void main() {
 
       await manager2.emptyCache();
       await manager2.dispose();
+    });
+
+    test('dispose waits for an in-flight cleanup sweep to finish', () async {
+      final cacheDir =
+          io.Directory.systemTemp.createTempSync('dispose_race_cache_');
+      addTearDown(() {
+        try {
+          cacheDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => cacheDir,
+        maxNrOfCacheObjects: 2,
+      );
+
+      final now = DateTime.now().millisecondsSinceEpoch;
+      const total = 30;
+      for (var i = 0; i < total; i++) {
+        await manager.putFile(
+          'https://example.com/dispose-race-$i-$now.bin',
+          [i],
+          fileExtension: 'bin',
+          maxAge: const Duration(hours: 1),
+        );
+      }
+      await manager.dispose();
+
+      // Re-initialize — construction triggers an unawaited cleanup sweep
+      // that must trim `total` entries down to maxNrOfCacheObjects.
+      final manager2 = DefaultCacheManager(
+        cacheDirectoryProvider: () async => cacheDir,
+        maxNrOfCacheObjects: 2,
+      );
+      await manager2.getFileFromCache('trigger-init-$now');
+
+      // No delay here: dispose() must itself wait for the cleanup sweep it
+      // kicked off during initialization before returning.
+      await manager2.dispose();
+
+      final hiveDir =
+          io.Directory('${cacheDir.path}/cached_network_image_ce/hive');
+      final hive = HiveImpl();
+      final box = await hive.openBox<Map>(
+        'cached_network_image_cache',
+        path: hiveDir.path,
+      );
+      expect(box.length, lessThanOrEqualTo(2));
+      await box.close();
+      await hive.close();
     });
   });
 

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -816,7 +816,7 @@ void main() {
       expect(await manager2.getFileFromCache(oldUrl), isNull);
       expect(await manager2.getFileFromCache(recentUrl), isNull);
 
-      for (var i = 0; i < 50; i++) {
+      for (var i = 0; i < 150; i++) {
         if (!oldFile.existsSync()) break;
         await Future<void>.delayed(const Duration(milliseconds: 20));
       }

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -123,8 +123,67 @@ void main() {
           io.Directory('${customDir.path}/cached_network_image_ce');
       expect(cacheSubDir.existsSync(), isTrue);
 
+      final hiveDir =
+          io.Directory('${customDir.path}/cached_network_image_ce/hive');
+      expect(hiveDir.existsSync(), isTrue);
+
       await manager.emptyCache();
       await manager.dispose();
+    });
+
+    test('accepts custom metadataDirectoryProvider', () async {
+      final cacheDir =
+          io.Directory.systemTemp.createTempSync('custom_file_cache_dir_');
+      final metadataDir =
+          io.Directory.systemTemp.createTempSync('custom_metadata_dir_');
+      addTearDown(() {
+        try {
+          cacheDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+        try {
+          metadataDir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        cacheDirectoryProvider: () async => cacheDir,
+        metadataDirectoryProvider: () async => metadataDir,
+      );
+
+      await manager.putFile(
+        'https://example.com/custom-metadata-dir.bin',
+        [1, 2, 3],
+        fileExtension: 'bin',
+      );
+
+      final cached = await manager.getFileFromCache(
+        'https://example.com/custom-metadata-dir.bin',
+      );
+      expect(cached, isNotNull);
+      expect(cached!.file.path, contains(cacheDir.path));
+      expect(cached.file.path, isNot(contains(metadataDir.path)));
+
+      final cacheHiveDir =
+          io.Directory('${cacheDir.path}/cached_network_image_ce/hive');
+      expect(cacheHiveDir.existsSync(), isFalse);
+
+      final metadataHiveDir =
+          io.Directory('${metadataDir.path}/cached_network_image_ce/hive');
+      expect(metadataHiveDir.existsSync(), isTrue);
+
+      await manager.dispose();
+
+      final hive = HiveImpl();
+      final box = await hive.openBox<Map>(
+        'cached_network_image_cache',
+        path: metadataHiveDir.path,
+      );
+      expect(
+        box.get('https://example.com/custom-metadata-dir.bin'),
+        isNotNull,
+      );
+      await box.close();
+      await hive.close();
     });
   });
 

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -918,13 +918,14 @@ void main() {
       );
       await managerA2.getFileFromCache('trigger-init');
 
-      // Give the sweep time to run; it should find nothing of B's to delete.
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+      // dispose() awaits the in-flight cleanup sweep, so by the time this
+      // returns the sweep has run to completion; it should find nothing of
+      // B's to delete.
+      await managerA2.dispose();
 
       expect(bFile.existsSync(), isTrue);
       expect(await managerB.getFileFromCache(bUrl), isNotNull);
 
-      await managerA2.dispose();
       await managerB.dispose();
     });
 


### PR DESCRIPTION
## Description

Adds `metadataDirectoryProvider` to `DefaultCacheManager`, allowing Hive metadata to be stored separately from cached image files on IO platforms.

This lets apps keep recoverable image files in a system cache/temp directory while storing Hive metadata in an app-controlled support or no-backup directory.

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `metadataDirectoryProvider` to store Hive metadata in a separate directory from cached image files on native IO platforms.
* **Documentation**
  * Updated the README with a “Cache and Metadata Directories” section, including configuration examples and default on-disk layout.
* **Bug Fixes**
  * Improved cache cleanup by removing orphaned cached files with a grace period and safer teardown behavior.
* **Tests**
  * Added/expanded tests to verify directory isolation, correct Hive box placement, orphan reconciliation behavior, and cleanup synchronization on dispose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->