### PR TITLE
fix: add ImageRenderMethodForWeb export

### DIFF
--- a/cached_network_image/lib/cached_network_image.dart
+++ b/cached_network_image/lib/cached_network_image.dart
@@ -15,6 +15,7 @@ export 'package:cached_network_image_platform_interface_ce/cached_network_image_
         HttpExceptionWithStatus,
         ImageCacheManager,
         ImageFormatDetector,
+        ImageRenderMethodForWeb,
         UnsupportedImageFormatException;
 
 export 'src/cache/cleanup_strategy.dart';

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -1,7 +1,6 @@
 import 'dart:typed_data';
 
 import 'package:cached_network_image_ce/cached_network_image.dart';
-import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:octo_image/octo_image.dart';

--- a/cached_network_image/test/image_loader_test.dart
+++ b/cached_network_image/test/image_loader_test.dart
@@ -5,8 +5,6 @@ import 'dart:ui' as ui;
 
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:cached_network_image_ce/src/image_provider/_image_loader.dart';
-import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart'
-    hide ImageLoader;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/cached_network_image/test/leak_test.dart
+++ b/cached_network_image/test/leak_test.dart
@@ -14,8 +14,6 @@ import 'package:cached_network_image_ce/cached_network_image.dart'
     hide DefaultCacheManager;
 import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
 import 'package:cached_network_image_ce/src/image_provider/_image_loader.dart';
-import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart'
-    hide ImageLoader;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Description

Added export of enum `ImageRenderMethodForWeb` in `cached_network_image/cached_network_image.dart`

## Related Issues

*Fixes #47*

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
  - could not test package `cached_network_image_web` because Flutter couldn't find any test
- [ ] I've added new tests for any new features or bug fixes
- [ ] I've updated the CHANGELOG if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed web image rendering method configuration as a public API option, enabling developers to customize how images are rendered on web platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->