### PR TITLE
Enhance unsupported image handling and bump version to 4.9.1

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.9.1] - 2026-07-23
+
+* **Fix:** Codec decode failures (e.g. JXL, or AVIF/HEIC on platforms without native support) now route to `unsupportedImageBuilder` instead of `errorBuilder`. Previously only pre-detected formats (SVG) were routed this way via `UnsupportedImageFormatException`; any other codec decode failure fell through as a generic, untyped error.
+
 ## [4.9.0] - 2026-06-19
 
 * **Feature:** Added `metadataDirectoryProvider` to `DefaultCacheManager` so Hive metadata can be stored separately from cached image files on IO platforms.

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -250,12 +250,17 @@ When `onStore` rejects, the downloaded file is copied to a system-temp location,
 cache-directory copy is deleted (no orphan), and the temp copy is yielded to the caller for
 this request only.
 
-### SVG Support
+### Unsupported Image Formats (SVG, JXL, AVIF, HEIC, ...)
 
-Flutter's built-in image codec doesn't support SVG. When `CachedNetworkImage`
-detects SVG bytes it throws an `UnsupportedImageFormatException`. Use the
-`unsupportedImageBuilder` callback to render them with any SVG package you
-prefer (e.g. [`flutter_svg`](https://pub.dev/packages/flutter_svg)):
+Flutter's built-in image codec can't decode every format — SVG never works
+(it's not a raster format), and some raster formats (JXL, AVIF, HEIC, ...) may
+fail depending on platform/OS codec support. When `CachedNetworkImage` detects
+SVG bytes, or the codec otherwise fails to decode the cached bytes, it throws
+an `UnsupportedImageFormatException` instead of leaving you with an opaque
+decode error. Use the `unsupportedImageBuilder` callback to render the raw
+bytes with a format-specific package of your choice — e.g.
+[`flutter_svg`](https://pub.dev/packages/flutter_svg) for SVG, or
+[`flutter_avif`](https://pub.dev/packages/flutter_avif) for AVIF:
 
 Before using `SvgPicture.memory`, add `flutter_svg` to `pubspec.yaml`
 (`dependencies: flutter_svg: ^2.2.1`) and import
@@ -276,6 +281,13 @@ CachedNetworkImage(
 The image is still downloaded and cached normally — only the **rendering**
 path is different. If `unsupportedImageBuilder` is not set, the error falls
 through to `errorWidget` with an `UnsupportedImageFormatException`.
+
+SVG is detected ahead of time, so its exception carries
+`detectedFormat: 'svg'`. Any other codec decode failure (JXL, AVIF, HEIC, or a
+genuinely corrupt file) is only caught once decoding is actually attempted, so
+`detectedFormat` is `null` in that case — check the bytes yourself (e.g. magic
+numbers) if you need to distinguish which format/decoder to use inside
+`unsupportedImageBuilder`.
 
 ## ❓ FAQ
 

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -289,6 +289,13 @@ genuinely corrupt file) is only caught once decoding is actually attempted, so
 numbers) if you need to distinguish which format/decoder to use inside
 `unsupportedImageBuilder`.
 
+**Web caveat:** this whole mechanism requires the raw cached bytes, so it only
+works with `ImageRenderMethodForWeb.HttpGet`. The default `HtmlImage` render
+method hands the URL straight to the browser's native image pipeline and never
+has bytes to inspect, so a decode failure there falls straight through to
+`errorBuilder`/`errorWidget` as a plain error, not an
+`UnsupportedImageFormatException`.
+
 ## ❓ FAQ
 
 **Q: Will I lose my users' existing cache if I migrate?**

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -112,7 +112,8 @@ class CachedNetworkImage extends StatefulWidget {
   final ImageErrorWidgetBuilder? errorBuilder;
 
   /// Builder for images whose format is not supported by Flutter's standard
-  /// image codec (e.g. SVG).
+  /// image codec (e.g. SVG, or any other format the codec fails to decode,
+  /// such as JXL, AVIF, or HEIC on platforms without native support).
   ///
   /// When set, the image is still downloaded and cached normally. If the
   /// cached bytes cannot be decoded as a raster image, this builder is called

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -123,6 +123,12 @@ class CachedNetworkImage extends StatefulWidget {
   /// If this is `null` and the image format is unsupported, the
   /// [errorWidget] builder is called instead (with an
   /// [UnsupportedImageFormatException]).
+  ///
+  /// On Flutter Web, this only applies when using
+  /// `ImageRenderMethodForWeb.HttpGet`. The default `HtmlImage` render
+  /// method decodes through the browser's native image pipeline and has no
+  /// access to the raw bytes, so decode failures there surface as a plain
+  /// error instead.
   final UnsupportedImageWidgetBuilder? unsupportedImageBuilder;
 
   /// The duration of the fade-in animation for the [placeholder].

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -129,7 +129,12 @@ class ImageLoader implements platform.ImageLoader {
               detectedFormat: unsupportedFormat,
             );
           }
-          final decoded = await decode(bytes);
+          final ui.Codec decoded;
+          try {
+            decoded = await decode(bytes);
+          } catch (_) {
+            throw UnsupportedImageFormatException(bytes: bytes, url: url);
+          }
           yield decoded;
         }
       }

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.9.0
+version: 4.9.1
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/jxl_support_test.dart
+++ b/cached_network_image/test/jxl_support_test.dart
@@ -1,0 +1,91 @@
+import 'dart:typed_data';
+
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_cache_manager.dart';
+
+/// Bytes that are neither a valid raster image nor SVG text, so the codec is
+/// guaranteed to fail to decode them. Deliberately not real JXL bytes: a real
+/// JXL sample could actually decode on some host codecs, which would make the
+/// test pass for the wrong reason.
+final Uint8List kUndecodableBytes = Uint8List.fromList(
+  [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07],
+);
+
+void main() {
+  late FakeCacheManager cacheManager;
+
+  setUp(() {
+    cacheManager = FakeCacheManager();
+  });
+
+  tearDown(() {
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
+  });
+
+  group('CachedNetworkImage codec decode failure (e.g. JXL)', () {
+    testWidgets(
+        'unsupportedImageBuilder is called when the codec fails to decode '
+        'bytes', (tester) async {
+      const imageUrl = 'undecodable-test';
+      cacheManager.returns(imageUrl, kUndecodableBytes);
+      Uint8List? receivedBytes;
+      String? receivedUrl;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              unsupportedImageBuilder: (context, url, bytes) {
+                receivedBytes = bytes;
+                receivedUrl = url;
+                return const Text('Unsupported rendered');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(receivedUrl, imageUrl);
+      expect(receivedBytes, kUndecodableBytes);
+      expect(find.text('Unsupported rendered'), findsOneWidget);
+    });
+
+    testWidgets(
+        'errorWidget receives UnsupportedImageFormatException with null '
+        'detectedFormat for a generic decode failure', (tester) async {
+      const imageUrl = 'undecodable-error-fallback-test';
+      cacheManager.returns(imageUrl, kUndecodableBytes);
+      Object? receivedError;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              errorWidget: (context, url, error) {
+                receivedError = error;
+                return const Text('Error fallback');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(receivedError, isA<UnsupportedImageFormatException>());
+      expect(
+        (receivedError as UnsupportedImageFormatException).detectedFormat,
+        isNull,
+      );
+      expect(find.text('Error fallback'), findsOneWidget);
+    });
+  });
+}

--- a/cached_network_image_platform_interface/lib/src/unsupported_image_format_exception.dart
+++ b/cached_network_image_platform_interface/lib/src/unsupported_image_format_exception.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
 /// Exception thrown when the image bytes cannot be decoded by Flutter's
-/// standard image codec (e.g. SVG images).
+/// standard image codec. This covers formats detected ahead of time (e.g.
+/// SVG images) as well as any other format the codec fails to decode at
+/// runtime (e.g. JXL, AVIF, or HEIC on platforms without native support).
 ///
 /// When caught, the [bytes] field contains the raw cached file bytes so that
 /// a custom renderer (such as `flutter_svg`) can display the image.

--- a/cached_network_image_web/CHANGELOG.md
+++ b/cached_network_image_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.2] - 2026-07-23
+
+* **Fix:** Codec decode failures now route to `unsupportedImageBuilder` instead of `errorBuilder`, matching the IO loader's behaviour. Previously only pre-detected formats (SVG) were routed this way.
+
 ## [2.1.1] - 2026-03-15
 
 * **Fix:** Enforce that HTTP headers can only be used with `HttpGet`. (PR #16)

--- a/cached_network_image_web/lib/cached_network_image_web_ce.dart
+++ b/cached_network_image_web/lib/cached_network_image_web_ce.dart
@@ -188,7 +188,15 @@ class ImageLoader implements platform.ImageLoader {
                     detectedFormat: unsupportedFormat,
                   );
                 }
-                final data = await decode(value);
+                final ui.Codec data;
+                try {
+                  data = await decode(value);
+                } catch (_) {
+                  throw UnsupportedImageFormatException(
+                    bytes: value,
+                    url: url,
+                  );
+                }
                 streamController.add(data);
                 if (state == _State.closing) {
                   streamController.close();

--- a/cached_network_image_web/pubspec.yaml
+++ b/cached_network_image_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cached_network_image_web_ce
 description: Web implementation of CachedNetworkImage (Community Edition)
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/Erengun/flutter_cached_network_image_ce
 repository: https://github.com/Erengun/flutter_cached_network_image_ce/tree/develop/cached_network_image_web
 topics:


### PR DESCRIPTION
## Description

Improve handling of unsupported image formats by routing codec decode failures to `unsupportedImageBuilder`, ensuring better error management for various formats like JXL, AVIF, and HEIC. Update version to 4.9.1 and reflect changes in the CHANGELOG.

## Related Issues

Fixes #55
Related to #34

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image decoding failures for unsupported formats such as JXL, AVIF, and HEIC are now routed to `unsupportedImageBuilder` instead of `errorBuilder`, including on the web HTTP loader path.
  * Unsupported image errors now consistently include the original bytes and URL to support format-specific rendering.
* **Documentation**
  * Expanded guidance for unsupported formats and decode-time failures, including when `detectedFormat` is set vs. left unset.
* **Tests**
  * Added tests to verify decode-failure handling and the `unsupportedImageBuilder`/`errorWidget` behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->