### PR TITLE
perf(cache): reuse HTTP client across downloads

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.10.0] - 2026-07-30
+
+* **Performance:** `DefaultCacheManager` now reuses a single HTTP client across downloads instead of creating and closing one per request, so connections can be kept alive between images.
+* **Fix:** A connection timeout now aborts the in-flight request instead of leaving it running in the background.
+* **Fix:** `dispose()` closes the reused client. Downloads started after disposal create their own client, which is closed once its last response is released.
+* **Behaviour change:** `dispose()` called while a download is in flight now aborts that download; previously each download owned its client and could outlive `dispose()`.
+* **Behaviour change:** An `onResponse` interceptor that replaces the response must not derive the replacement body from the original response's stream — the original body is now canceled as soon as it is replaced, to release its connection.
+
+contributed by [@Chlx42](https://github.com/Chlx42) — thanks! (PR #58)
+
 ## [4.9.0] - 2026-06-19
 
 * **Feature:** Added `metadataDirectoryProvider` to `DefaultCacheManager` so Hive metadata can be stored separately from cached image files on IO platforms.

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -395,26 +395,54 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     }
 
     final proceed = reqOutcome as HttpRequestProceed;
+    final abortCompleter = Completer<void>();
+    http.StreamedResponse? rawResponse;
     try {
-      final request = http.Request('GET', Uri.parse(proceed.data.url));
+      final request = http.AbortableRequest(
+        'GET',
+        Uri.parse(proceed.data.url),
+        abortTrigger: abortCompleter.future,
+      );
       if (proceed.data.headers.isNotEmpty) {
         request.headers.addAll(proceed.data.headers);
       }
 
       final connectionTimeout = connectionParameters?.connectionTimeout;
-      final rawResponse = connectionTimeout != null
-          ? await _client.send(request).timeout(connectionTimeout)
-          : await _client.send(request);
+      final sendFuture = _client.send(request);
+      final response = connectionTimeout != null
+          ? await sendFuture.timeout(
+              connectionTimeout,
+              onTimeout: () {
+                if (!abortCompleter.isCompleted) {
+                  abortCompleter.complete();
+                }
+                throw TimeoutException(
+                  'Connection timed out after $connectionTimeout',
+                  connectionTimeout,
+                );
+              },
+            )
+          : await sendFuture;
+      rawResponse = response;
 
       // Splice 2: run onResponse chain — interceptors may replace the response
       final processedRes = await runOnResponseChain(
         _httpInterceptors,
-        HttpResponseData(response: rawResponse, originalUrl: url),
+        HttpResponseData(response: response, originalUrl: url),
       );
+      if (!identical(processedRes.response, response)) {
+        await _cancelResponseStream(response);
+        rawResponse = null;
+      }
 
       // _processResponse reads the stream; client must remain open until done
       yield* _processResponse(url, key, withProgress, processedRes);
     } catch (e, st) {
+      final response = rawResponse;
+      if (response != null) {
+        await _cancelResponseStream(response);
+      }
+
       // Splice 3: run onError chain for all errors (network, status, stream)
       final errorOutcome = await runOnErrorChain(_httpInterceptors, e, st);
       if (errorOutcome is HttpErrorResolved) {
@@ -423,6 +451,22 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       }
       final rethrow_ = errorOutcome as HttpErrorRethrow;
       Error.throwWithStackTrace(rethrow_.error, rethrow_.stackTrace);
+    } finally {
+      if (!abortCompleter.isCompleted) {
+        abortCompleter.complete();
+      }
+    }
+  }
+
+  Future<void> _cancelResponseStream(http.StreamedResponse response) async {
+    try {
+      final subscription = response.stream.listen(
+        null,
+        onError: (Object _, StackTrace __) {},
+      );
+      await subscription.cancel();
+    } on Object catch (_) {
+      // The stream may already have been consumed or canceled.
     }
   }
 
@@ -439,6 +483,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     final response = resData.response;
 
     if (response.statusCode != 200 && response.statusCode != 202) {
+      await _cancelResponseStream(response);
       throw HttpExceptionWithStatus(
         response.statusCode,
         'Invalid statusCode: ${response.statusCode}',

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -21,6 +21,7 @@ import 'cleanup_strategy.dart';
 import 'interceptors/cache_interceptor.dart';
 import 'interceptors/http_interceptor.dart';
 import 'interceptors/interceptor_runner.dart';
+import 'shared_http_client.dart';
 
 export 'cache_entry_metadata.dart';
 
@@ -69,7 +70,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     List<HttpInterceptor> httpInterceptors = const [],
     List<CacheInterceptor> cacheInterceptors = const [],
     CleanupStrategy? cleanupStrategy,
-  })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
+  })  : _httpClient = SharedHttpClient(httpClientFactory ?? http.Client.new),
         _cacheDirectoryProvider =
             cacheDirectoryProvider ?? getTemporaryDirectory,
         _metadataDirectoryProvider = metadataDirectoryProvider,
@@ -89,12 +90,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// wait indefinitely — preserving the existing behaviour.
   final ConnectionParameters? connectionParameters;
 
-  /// Factory for lazily creating the shared HTTP client.
-  final http.Client Function() _httpClientFactory;
-
-  http.Client? _httpClient;
-
-  http.Client get _client => _httpClient ??= _httpClientFactory();
+  final SharedHttpClient _httpClient;
 
   /// Provider for the base cache directory.
   final CacheDirectoryProvider _cacheDirectoryProvider;
@@ -395,34 +391,15 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     }
 
     final proceed = reqOutcome as HttpRequestProceed;
-    final abortCompleter = Completer<void>();
+    SharedHttpClientResponse? clientResponse;
     http.StreamedResponse? rawResponse;
     try {
-      final request = http.AbortableRequest(
-        'GET',
-        Uri.parse(proceed.data.url),
-        abortTrigger: abortCompleter.future,
+      clientResponse = await _httpClient.send(
+        uri: Uri.parse(proceed.data.url),
+        headers: proceed.data.headers,
+        connectionTimeout: connectionParameters?.connectionTimeout,
       );
-      if (proceed.data.headers.isNotEmpty) {
-        request.headers.addAll(proceed.data.headers);
-      }
-
-      final connectionTimeout = connectionParameters?.connectionTimeout;
-      final sendFuture = _client.send(request);
-      final response = connectionTimeout != null
-          ? await sendFuture.timeout(
-              connectionTimeout,
-              onTimeout: () {
-                if (!abortCompleter.isCompleted) {
-                  abortCompleter.complete();
-                }
-                throw TimeoutException(
-                  'Connection timed out after $connectionTimeout',
-                  connectionTimeout,
-                );
-              },
-            )
-          : await sendFuture;
+      final response = clientResponse.response;
       rawResponse = response;
 
       // Splice 2: run onResponse chain — interceptors may replace the response
@@ -432,6 +409,11 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       );
       if (!identical(processedRes.response, response)) {
         await _cancelResponseStream(response);
+        rawResponse = null;
+      }
+      if (processedRes.response.statusCode != 200 &&
+          processedRes.response.statusCode != 202) {
+        // _processResponse owns cancellation for invalid responses.
         rawResponse = null;
       }
 
@@ -452,9 +434,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final rethrow_ = errorOutcome as HttpErrorRethrow;
       Error.throwWithStackTrace(rethrow_.error, rethrow_.stackTrace);
     } finally {
-      if (!abortCompleter.isCompleted) {
-        abortCompleter.complete();
-      }
+      clientResponse?.release();
     }
   }
 
@@ -465,8 +445,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         onError: (Object _, StackTrace __) {},
       );
       await subscription.cancel();
-    } on Object catch (_) {
-      // The stream may already have been consumed or canceled.
+    } on StateError catch (_) {
+      // A downstream owner may already have consumed the single-subscription
+      // stream. Other cleanup failures should remain visible.
     }
   }
 
@@ -756,9 +737,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       }
     }
 
-    final client = _httpClient;
-    _httpClient = null;
-    client?.close();
+    _httpClient.dispose();
 
     if (_cacheBox != null && _cacheBox!.isOpen) {
       try {

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -89,8 +89,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// wait indefinitely — preserving the existing behaviour.
   final ConnectionParameters? connectionParameters;
 
-  /// Factory for creating HTTP clients (injectable for testing).
+  /// Factory for lazily creating the shared HTTP client.
   final http.Client Function() _httpClientFactory;
+
+  http.Client? _httpClient;
+
+  http.Client get _client => _httpClient ??= _httpClientFactory();
 
   /// Provider for the base cache directory.
   final CacheDirectoryProvider _cacheDirectoryProvider;
@@ -391,7 +395,6 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     }
 
     final proceed = reqOutcome as HttpRequestProceed;
-    final client = _httpClientFactory();
     try {
       final request = http.Request('GET', Uri.parse(proceed.data.url));
       if (proceed.data.headers.isNotEmpty) {
@@ -400,8 +403,8 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
       final connectionTimeout = connectionParameters?.connectionTimeout;
       final rawResponse = connectionTimeout != null
-          ? await client.send(request).timeout(connectionTimeout)
-          : await client.send(request);
+          ? await _client.send(request).timeout(connectionTimeout)
+          : await _client.send(request);
 
       // Splice 2: run onResponse chain — interceptors may replace the response
       final processedRes = await runOnResponseChain(
@@ -420,9 +423,6 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       }
       final rethrow_ = errorOutcome as HttpErrorRethrow;
       Error.throwWithStackTrace(rethrow_.error, rethrow_.stackTrace);
-    } finally {
-      // client.close() runs after the stream is consumed (normal path) or on error
-      client.close();
     }
   }
 
@@ -710,6 +710,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         // Already logged inside _cleanupOldFiles; ignore here.
       }
     }
+
+    final client = _httpClient;
+    _httpClient = null;
+    client?.close();
 
     if (_cacheBox != null && _cacheBox!.isOpen) {
       try {

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -12,6 +12,7 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 
 import 'cache_entry_metadata.dart';
+import 'shared_http_client.dart';
 
 export 'cache_entry_metadata.dart';
 
@@ -48,7 +49,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     this.connectionParameters,
     http.Client Function()? httpClientFactory,
     @visibleForTesting HiveInterface? hiveInstance,
-  })  : _httpClientFactory = httpClientFactory ?? http.Client.new,
+  })  : _httpClient = SharedHttpClient(httpClientFactory ?? http.Client.new),
         _hive = hiveInstance ?? HiveImpl();
 
   /// Duration before cached files are considered stale.
@@ -68,12 +69,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// handled by the browser.
   final ConnectionParameters? connectionParameters;
 
-  /// Factory for lazily creating the shared HTTP client.
-  final http.Client Function() _httpClientFactory;
-
-  http.Client? _httpClient;
-
-  http.Client get _client => _httpClient ??= _httpClientFactory();
+  final SharedHttpClient _httpClient;
 
   /// In-memory file system used to materialise cached bytes as [File] objects.
   final MemoryFileSystem _memFs = MemoryFileSystem();
@@ -254,33 +250,14 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       CacheManagerLogLevel.verbose,
     );
 
-    final abortCompleter = Completer<void>();
-    final request = http.AbortableRequest(
-      'GET',
-      Uri.parse(url),
-      abortTrigger: abortCompleter.future,
-    );
-    if (headers != null) {
-      request.headers.addAll(headers);
-    }
-
+    SharedHttpClientResponse? clientResponse;
     try {
-      final connectionTimeout = connectionParameters?.connectionTimeout;
-      final sendFuture = _client.send(request);
-      final response = connectionTimeout != null
-          ? await sendFuture.timeout(
-              connectionTimeout,
-              onTimeout: () {
-                if (!abortCompleter.isCompleted) {
-                  abortCompleter.complete();
-                }
-                throw TimeoutException(
-                  'Connection timed out after $connectionTimeout',
-                  connectionTimeout,
-                );
-              },
-            )
-          : await sendFuture;
+      clientResponse = await _httpClient.send(
+        uri: Uri.parse(url),
+        headers: headers,
+        connectionTimeout: connectionParameters?.connectionTimeout,
+      );
+      final response = clientResponse.response;
 
       if (response.statusCode != 200 && response.statusCode != 202) {
         throw HttpExceptionWithStatus(
@@ -330,9 +307,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       final file = _bytesToFile(relativePath, allBytes);
       yield FileInfo(file, FileSource.Online, validTill, url);
     } finally {
-      if (!abortCompleter.isCompleted) {
-        abortCompleter.complete();
-      }
+      clientResponse?.release();
     }
   }
 
@@ -449,9 +424,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       }
     }
 
-    final client = _httpClient;
-    _httpClient = null;
-    client?.close();
+    _httpClient.dispose();
 
     if (_metaBox != null && _metaBox!.isOpen) {
       await _metaBox!.close();

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -68,8 +68,12 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
   /// handled by the browser.
   final ConnectionParameters? connectionParameters;
 
-  /// Factory for creating HTTP clients.
+  /// Factory for lazily creating the shared HTTP client.
   final http.Client Function() _httpClientFactory;
+
+  http.Client? _httpClient;
+
+  http.Client get _client => _httpClient ??= _httpClientFactory();
 
   /// In-memory file system used to materialise cached bytes as [File] objects.
   final MemoryFileSystem _memFs = MemoryFileSystem();
@@ -255,63 +259,58 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       request.headers.addAll(headers);
     }
 
-    final client = _httpClientFactory();
-    try {
-      final connectionTimeout = connectionParameters?.connectionTimeout;
-      final response = connectionTimeout != null
-          ? await client.send(request).timeout(connectionTimeout)
-          : await client.send(request);
+    final connectionTimeout = connectionParameters?.connectionTimeout;
+    final response = connectionTimeout != null
+        ? await _client.send(request).timeout(connectionTimeout)
+        : await _client.send(request);
 
-      if (response.statusCode != 200 && response.statusCode != 202) {
-        throw HttpExceptionWithStatus(
-          response.statusCode,
-          'Invalid statusCode: ${response.statusCode}',
-          uri: Uri.parse(url),
-        );
-      }
-
-      final contentLength = response.contentLength;
-      final allBytes = <int>[];
-      var receivedBytes = 0;
-
-      final requestTimeout = connectionParameters?.requestTimeout;
-      final stream = requestTimeout != null
-          ? response.stream.timeout(requestTimeout)
-          : response.stream;
-
-      await for (final chunk in stream) {
-        receivedBytes += chunk.length;
-        allBytes.addAll(chunk);
-        if (withProgress) {
-          yield DownloadProgress(url, contentLength, receivedBytes);
-        }
-      }
-
-      // Store metadata + data in Hive.
-      final validTill = DateTime.now().add(stalePeriod);
-      final cacheHeaders = response.headers;
-      final eTag = cacheHeaders['etag'];
-      final fileExtension = _getFileExtensionFromUrl(url);
-      final relativePath =
-          '${key.hashCode.toUnsigned(32).toRadixString(16)}.$fileExtension';
-
-      await _metaBox!.put(
-        _sanitizeBoxKey(key),
-        CacheEntryMetadata(
-          url: url,
-          relativePath: relativePath,
-          validTill: validTill,
-          eTag: eTag,
-          length: receivedBytes,
-        ).toMap(),
+    if (response.statusCode != 200 && response.statusCode != 202) {
+      throw HttpExceptionWithStatus(
+        response.statusCode,
+        'Invalid statusCode: ${response.statusCode}',
+        uri: Uri.parse(url),
       );
-      await _dataBox!.put(_sanitizeBoxKey(key), allBytes);
-
-      final file = _bytesToFile(relativePath, allBytes);
-      yield FileInfo(file, FileSource.Online, validTill, url);
-    } finally {
-      client.close();
     }
+
+    final contentLength = response.contentLength;
+    final allBytes = <int>[];
+    var receivedBytes = 0;
+
+    final requestTimeout = connectionParameters?.requestTimeout;
+    final stream = requestTimeout != null
+        ? response.stream.timeout(requestTimeout)
+        : response.stream;
+
+    await for (final chunk in stream) {
+      receivedBytes += chunk.length;
+      allBytes.addAll(chunk);
+      if (withProgress) {
+        yield DownloadProgress(url, contentLength, receivedBytes);
+      }
+    }
+
+    // Store metadata + data in Hive.
+    final validTill = DateTime.now().add(stalePeriod);
+    final cacheHeaders = response.headers;
+    final eTag = cacheHeaders['etag'];
+    final fileExtension = _getFileExtensionFromUrl(url);
+    final relativePath =
+        '${key.hashCode.toUnsigned(32).toRadixString(16)}.$fileExtension';
+
+    await _metaBox!.put(
+      _sanitizeBoxKey(key),
+      CacheEntryMetadata(
+        url: url,
+        relativePath: relativePath,
+        validTill: validTill,
+        eTag: eTag,
+        length: receivedBytes,
+      ).toMap(),
+    );
+    await _dataBox!.put(_sanitizeBoxKey(key), allBytes);
+
+    final file = _bytesToFile(relativePath, allBytes);
+    yield FileInfo(file, FileSource.Online, validTill, url);
   }
 
   @override
@@ -426,6 +425,10 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         // Ignore init errors during dispose.
       }
     }
+
+    final client = _httpClient;
+    _httpClient = null;
+    client?.close();
 
     if (_metaBox != null && _metaBox!.isOpen) {
       await _metaBox!.close();

--- a/cached_network_image/lib/src/cache/default_cache_manager_web.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager_web.dart
@@ -254,63 +254,86 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       CacheManagerLogLevel.verbose,
     );
 
-    final request = http.Request('GET', Uri.parse(url));
+    final abortCompleter = Completer<void>();
+    final request = http.AbortableRequest(
+      'GET',
+      Uri.parse(url),
+      abortTrigger: abortCompleter.future,
+    );
     if (headers != null) {
       request.headers.addAll(headers);
     }
 
-    final connectionTimeout = connectionParameters?.connectionTimeout;
-    final response = connectionTimeout != null
-        ? await _client.send(request).timeout(connectionTimeout)
-        : await _client.send(request);
+    try {
+      final connectionTimeout = connectionParameters?.connectionTimeout;
+      final sendFuture = _client.send(request);
+      final response = connectionTimeout != null
+          ? await sendFuture.timeout(
+              connectionTimeout,
+              onTimeout: () {
+                if (!abortCompleter.isCompleted) {
+                  abortCompleter.complete();
+                }
+                throw TimeoutException(
+                  'Connection timed out after $connectionTimeout',
+                  connectionTimeout,
+                );
+              },
+            )
+          : await sendFuture;
 
-    if (response.statusCode != 200 && response.statusCode != 202) {
-      throw HttpExceptionWithStatus(
-        response.statusCode,
-        'Invalid statusCode: ${response.statusCode}',
-        uri: Uri.parse(url),
+      if (response.statusCode != 200 && response.statusCode != 202) {
+        throw HttpExceptionWithStatus(
+          response.statusCode,
+          'Invalid statusCode: ${response.statusCode}',
+          uri: Uri.parse(url),
+        );
+      }
+
+      final contentLength = response.contentLength;
+      final allBytes = <int>[];
+      var receivedBytes = 0;
+
+      final requestTimeout = connectionParameters?.requestTimeout;
+      final stream = requestTimeout != null
+          ? response.stream.timeout(requestTimeout)
+          : response.stream;
+
+      await for (final chunk in stream) {
+        receivedBytes += chunk.length;
+        allBytes.addAll(chunk);
+        if (withProgress) {
+          yield DownloadProgress(url, contentLength, receivedBytes);
+        }
+      }
+
+      // Store metadata + data in Hive.
+      final validTill = DateTime.now().add(stalePeriod);
+      final cacheHeaders = response.headers;
+      final eTag = cacheHeaders['etag'];
+      final fileExtension = _getFileExtensionFromUrl(url);
+      final relativePath =
+          '${key.hashCode.toUnsigned(32).toRadixString(16)}.$fileExtension';
+
+      await _metaBox!.put(
+        _sanitizeBoxKey(key),
+        CacheEntryMetadata(
+          url: url,
+          relativePath: relativePath,
+          validTill: validTill,
+          eTag: eTag,
+          length: receivedBytes,
+        ).toMap(),
       );
-    }
+      await _dataBox!.put(_sanitizeBoxKey(key), allBytes);
 
-    final contentLength = response.contentLength;
-    final allBytes = <int>[];
-    var receivedBytes = 0;
-
-    final requestTimeout = connectionParameters?.requestTimeout;
-    final stream = requestTimeout != null
-        ? response.stream.timeout(requestTimeout)
-        : response.stream;
-
-    await for (final chunk in stream) {
-      receivedBytes += chunk.length;
-      allBytes.addAll(chunk);
-      if (withProgress) {
-        yield DownloadProgress(url, contentLength, receivedBytes);
+      final file = _bytesToFile(relativePath, allBytes);
+      yield FileInfo(file, FileSource.Online, validTill, url);
+    } finally {
+      if (!abortCompleter.isCompleted) {
+        abortCompleter.complete();
       }
     }
-
-    // Store metadata + data in Hive.
-    final validTill = DateTime.now().add(stalePeriod);
-    final cacheHeaders = response.headers;
-    final eTag = cacheHeaders['etag'];
-    final fileExtension = _getFileExtensionFromUrl(url);
-    final relativePath =
-        '${key.hashCode.toUnsigned(32).toRadixString(16)}.$fileExtension';
-
-    await _metaBox!.put(
-      _sanitizeBoxKey(key),
-      CacheEntryMetadata(
-        url: url,
-        relativePath: relativePath,
-        validTill: validTill,
-        eTag: eTag,
-        length: receivedBytes,
-      ).toMap(),
-    );
-    await _dataBox!.put(_sanitizeBoxKey(key), allBytes);
-
-    final file = _bytesToFile(relativePath, allBytes);
-    yield FileInfo(file, FileSource.Online, validTill, url);
   }
 
   @override

--- a/cached_network_image/lib/src/cache/interceptors/http_interceptor.dart
+++ b/cached_network_image/lib/src/cache/interceptors/http_interceptor.dart
@@ -54,6 +54,11 @@ class HttpRequestHandler {
 /// all remaining interceptors and return this response immediately, or
 /// [reject] to convert the response into an error.
 ///
+/// A replacement response must not derive its body from the original
+/// response's stream. Once the chain returns a different response instance,
+/// the original body is canceled to release its connection, and reading a
+/// stream derived from it throws a [StateError].
+///
 /// `.create()` is for internal use by the package only.
 class HttpResponseHandler {
   @internal

--- a/cached_network_image/lib/src/cache/shared_http_client.dart
+++ b/cached_network_image/lib/src/cache/shared_http_client.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+
+/// Owns a lazily created HTTP client and request-local abort lifecycles.
+///
+/// Before [dispose], downloads reuse the current client. After [dispose], the
+/// manager may still be used, so a new client is created on demand and closed
+/// as soon as its last active response is released.
+///
+/// Completing the abort trigger is sufficient to release an unread response
+/// in `BrowserClient`. `IOClient` additionally requires the caller to listen to
+/// and cancel an unread response stream after headers have arrived.
+final class SharedHttpClient {
+  SharedHttpClient(this._clientFactory);
+
+  final http.Client Function() _clientFactory;
+
+  _ClientEntry? _currentEntry;
+  bool _closeWhenIdle = false;
+
+  Future<SharedHttpClientResponse> send({
+    required Uri uri,
+    Map<String, String>? headers,
+    Duration? connectionTimeout,
+  }) async {
+    final entry = _acquire();
+    final abortCompleter = Completer<void>();
+    try {
+      final request = http.AbortableRequest(
+        'GET',
+        uri,
+        abortTrigger: abortCompleter.future,
+      );
+      if (headers != null && headers.isNotEmpty) {
+        request.headers.addAll(headers);
+      }
+
+      final sendFuture = entry.client.send(request);
+      final response = connectionTimeout == null
+          ? await sendFuture
+          : await sendFuture.timeout(
+              connectionTimeout,
+              onTimeout: () {
+                abortCompleter.complete();
+                throw TimeoutException(
+                  'Connection timed out after $connectionTimeout',
+                  connectionTimeout,
+                );
+              },
+            );
+
+      return SharedHttpClientResponse._(
+        response,
+        abortCompleter,
+        () => _release(entry),
+      );
+    } on Object catch (_) {
+      if (!abortCompleter.isCompleted) {
+        abortCompleter.complete();
+      }
+      _release(entry);
+      rethrow;
+    }
+  }
+
+  /// Closes the current client and makes future clients close when idle.
+  ///
+  /// Cache managers in this package support operations after disposal. Keeping
+  /// this mode enabled ensures those later operations cannot leave a new
+  /// long-lived client behind.
+  void dispose() {
+    _closeWhenIdle = true;
+    final entry = _currentEntry;
+    _currentEntry = null;
+    entry?.close();
+  }
+
+  _ClientEntry _acquire() {
+    final entry = _currentEntry ??= _ClientEntry(_clientFactory());
+    entry.activeResponses++;
+    return entry;
+  }
+
+  void _release(_ClientEntry entry) {
+    entry.activeResponses--;
+    if (_closeWhenIdle &&
+        entry.activeResponses == 0 &&
+        identical(_currentEntry, entry)) {
+      _currentEntry = null;
+      entry.close();
+    }
+  }
+}
+
+final class SharedHttpClientResponse {
+  SharedHttpClientResponse._(
+    this.response,
+    this._abortCompleter,
+    this._releaseClient,
+  );
+
+  final http.StreamedResponse response;
+  final Completer<void> _abortCompleter;
+  final void Function() _releaseClient;
+
+  bool _released = false;
+
+  /// Ends this response's abort lifecycle and releases its client lease.
+  void release() {
+    if (_released) return;
+    _released = true;
+    if (!_abortCompleter.isCompleted) {
+      _abortCompleter.complete();
+    }
+    _releaseClient();
+  }
+}
+
+final class _ClientEntry {
+  _ClientEntry(this.client);
+
+  final http.Client client;
+  int activeResponses = 0;
+  bool _closed = false;
+
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    client.close();
+  }
+}

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.9.0
+version: 4.10.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1415,9 +1415,20 @@ void main() {
 
     test('error on HTTP 404 is propagated to stream (no cached file)',
         () async {
+      var responseBodyCanceled = false;
       manager = DefaultCacheManager(
-        httpClientFactory: () => http_testing.MockClient(
-          (request) async => http.Response('Not Found', 404),
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            late final StreamController<List<int>> controller;
+            controller = StreamController<List<int>>(
+              onCancel: () async {
+                responseBodyCanceled = true;
+                await controller.close();
+              },
+            );
+            controller.add([1, 2, 3]);
+            return http.StreamedResponse(controller.stream, 404);
+          },
         ),
       );
 
@@ -1432,6 +1443,7 @@ void main() {
 
       expect(caughtError, isA<HttpExceptionWithStatus>());
       expect((caughtError! as HttpExceptionWithStatus).statusCode, 404);
+      expect(responseBodyCanceled, isTrue);
     });
 
     test('error on HTTP 500 is propagated to stream', () async {
@@ -1960,33 +1972,82 @@ void main() {
     test('client remains open after connection timeout until dispose',
         () async {
       var clientClosed = false;
+      var requestAborted = false;
 
       manager = DefaultCacheManager(
         connectionParameters: ConnectionParameters(
           connectionTimeout: const Duration(milliseconds: 50),
         ),
-        httpClientFactory: () {
-          final inner = http_testing.MockClient.streaming(
-            (request, bodyStream) async {
-              await Future<void>.delayed(const Duration(seconds: 10));
-              return http.StreamedResponse(const Stream.empty(), 200);
-            },
-          );
-          return _TimeoutCloseTrackingClient(inner, onClose: () {
+        httpClientFactory: () => _AbortTrackingClient(
+          onAbort: () {
+            requestAborted = true;
+          },
+          onClose: () {
             clientClosed = true;
-          });
-        },
+          },
+        ),
       );
 
+      Object? error;
       try {
         await manager
             .getFileStream('https://example.com/close-test.png')
             .toList();
-      } on Object catch (_) {}
+      } on Object catch (caught) {
+        error = caught;
+      }
 
+      await Future<void>.delayed(Duration.zero);
+      expect(error, isA<TimeoutException>());
+      expect(requestAborted, isTrue);
       expect(clientClosed, isFalse);
       await manager.dispose();
       expect(clientClosed, isTrue);
+    });
+
+    test('connection timeout does not abort response body after headers',
+        () async {
+      var bodyCompleted = false;
+      var abortTriggerCompleted = false;
+      var abortedBeforeBodyCompleted = false;
+
+      manager = DefaultCacheManager(
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(milliseconds: 20),
+        ),
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            final abortable = request as http.Abortable;
+            unawaited(abortable.abortTrigger!.then((_) {
+              abortTriggerCompleted = true;
+              if (!bodyCompleted) {
+                abortedBeforeBodyCompleted = true;
+              }
+            }));
+
+            final controller = StreamController<List<int>>();
+            unawaited(Future<void>.delayed(
+              const Duration(milliseconds: 50),
+              () async {
+                controller.add([1, 2, 3]);
+                bodyCompleted = true;
+                await controller.close();
+              },
+            ));
+            return http.StreamedResponse(controller.stream, 200);
+          },
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/slow-body.png')
+          .toList();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events.whereType<FileInfo>(), isNotEmpty);
+      expect(bodyCompleted, isTrue);
+      expect(abortTriggerCompleted, isTrue);
+      expect(abortedBeforeBodyCompleted, isFalse);
     });
   });
 
@@ -2344,21 +2405,25 @@ void main() {
   });
 }
 
-/// A wrapper around [http.Client] that tracks whether [close] was called.
-class _TimeoutCloseTrackingClient extends http.BaseClient {
-  _TimeoutCloseTrackingClient(this._inner, {required this.onClose});
+class _AbortTrackingClient extends http.BaseClient {
+  _AbortTrackingClient({
+    required this.onAbort,
+    required this.onClose,
+  });
 
-  final http.Client _inner;
+  final void Function() onAbort;
   final void Function() onClose;
 
   @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
-    return _inner.send(request);
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final abortable = request as http.Abortable;
+    await abortable.abortTrigger;
+    onAbort();
+    throw http.RequestAbortedException(request.url);
   }
 
   @override
   void close() {
     onClose();
-    _inner.close();
   }
 }

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1957,7 +1957,8 @@ void main() {
       expect(fileInfos.first.source.name, 'Online');
     });
 
-    test('client is closed even when connectionTimeout fires', () async {
+    test('client remains open after connection timeout until dispose',
+        () async {
       var clientClosed = false;
 
       manager = DefaultCacheManager(
@@ -1983,8 +1984,9 @@ void main() {
             .toList();
       } on Object catch (_) {}
 
-      expect(clientClosed, isTrue,
-          reason: 'http.Client must be closed even on timeout');
+      expect(clientClosed, isFalse);
+      await manager.dispose();
+      expect(clientClosed, isTrue);
     });
   });
 

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -13,6 +13,8 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 
+import 'support/http_clients.dart';
+
 /// A custom object that forces Hive to write a user-defined typeId into
 /// the box file. When the box is later opened without this adapter
 /// registered, Hive throws [HiveError] with "unknown typeId".
@@ -1978,7 +1980,7 @@ void main() {
         connectionParameters: ConnectionParameters(
           connectionTimeout: const Duration(milliseconds: 50),
         ),
-        httpClientFactory: () => _AbortTrackingClient(
+        httpClientFactory: () => AbortTrackingClient(
           onAbort: () {
             requestAborted = true;
           },
@@ -2403,27 +2405,4 @@ void main() {
       await manager.dispose();
     });
   });
-}
-
-class _AbortTrackingClient extends http.BaseClient {
-  _AbortTrackingClient({
-    required this.onAbort,
-    required this.onClose,
-  });
-
-  final void Function() onAbort;
-  final void Function() onClose;
-
-  @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    final abortable = request as http.Abortable;
-    await abortable.abortTrigger;
-    onAbort();
-    throw http.RequestAbortedException(request.url);
-  }
-
-  @override
-  void close() {
-    onClose();
-  }
 }

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -1149,34 +1149,84 @@ void main() {
     test('client remains open after connection timeout until dispose',
         () async {
       var clientClosed = false;
+      var requestAborted = false;
 
       manager = DefaultCacheManager(
         hiveInstance: testHive,
         connectionParameters: ConnectionParameters(
           connectionTimeout: const Duration(milliseconds: 50),
         ),
-        httpClientFactory: () {
-          final inner = http_testing.MockClient.streaming(
-            (request, bodyStream) async {
-              await Future<void>.delayed(const Duration(seconds: 10));
-              return http.StreamedResponse(const Stream.empty(), 200);
-            },
-          );
-          return _CloseTrackingClient(inner, onClose: () {
+        httpClientFactory: () => _AbortTrackingClient(
+          onAbort: () {
+            requestAborted = true;
+          },
+          onClose: () {
             clientClosed = true;
-          });
-        },
+          },
+        ),
       );
 
+      Object? error;
       try {
         await manager
             .getFileStream('https://example.com/close-test.png')
             .toList();
-      } on Object catch (_) {}
+      } on Object catch (caught) {
+        error = caught;
+      }
 
+      await Future<void>.delayed(Duration.zero);
+      expect(error, isA<TimeoutException>());
+      expect(requestAborted, isTrue);
       expect(clientClosed, isFalse);
       await manager.dispose();
       expect(clientClosed, isTrue);
+    });
+
+    test('connection timeout does not abort response body after headers',
+        () async {
+      var bodyCompleted = false;
+      var abortTriggerCompleted = false;
+      var abortedBeforeBodyCompleted = false;
+
+      manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        connectionParameters: ConnectionParameters(
+          connectionTimeout: const Duration(milliseconds: 20),
+        ),
+        httpClientFactory: () => http_testing.MockClient.streaming(
+          (request, bodyStream) async {
+            final abortable = request as http.Abortable;
+            unawaited(abortable.abortTrigger!.then((_) {
+              abortTriggerCompleted = true;
+              if (!bodyCompleted) {
+                abortedBeforeBodyCompleted = true;
+              }
+            }));
+
+            final controller = StreamController<List<int>>();
+            unawaited(Future<void>.delayed(
+              const Duration(milliseconds: 50),
+              () async {
+                controller.add([1, 2, 3]);
+                bodyCompleted = true;
+                await controller.close();
+              },
+            ));
+            return http.StreamedResponse(controller.stream, 200);
+          },
+        ),
+      );
+
+      final events = await manager
+          .getFileStream('https://example.com/slow-body.png')
+          .toList();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events.whereType<FileInfo>(), isNotEmpty);
+      expect(bodyCompleted, isTrue);
+      expect(abortTriggerCompleted, isTrue);
+      expect(abortedBeforeBodyCompleted, isFalse);
     });
   });
 
@@ -1228,5 +1278,28 @@ class _CloseTrackingClient extends http.BaseClient {
   void close() {
     onClose();
     _inner.close();
+  }
+}
+
+class _AbortTrackingClient extends http.BaseClient {
+  _AbortTrackingClient({
+    required this.onAbort,
+    required this.onClose,
+  });
+
+  final void Function() onAbort;
+  final void Function() onClose;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final abortable = request as http.Abortable;
+    await abortable.abortTrigger;
+    onAbort();
+    throw http.RequestAbortedException(request.url);
+  }
+
+  @override
+  void close() {
+    onClose();
   }
 }

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -10,6 +10,8 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 
+import 'support/http_clients.dart';
+
 /// A custom object that forces Hive to write a user-defined typeId into
 /// the box file. When the box is later opened without this adapter
 /// registered, Hive throws [HiveError] with "unknown typeId".
@@ -994,7 +996,8 @@ void main() {
       expect(closeCalls, 1);
     });
 
-    test('download after dispose creates a new http.Client', () async {
+    test('download after dispose creates and closes a new http.Client',
+        () async {
       var factoryCalls = 0;
       var closeCalls = 0;
       final manager = DefaultCacheManager(
@@ -1022,7 +1025,7 @@ void main() {
           .toList();
 
       expect(factoryCalls, 2);
-      expect(closeCalls, 1);
+      expect(closeCalls, 2);
 
       await manager.dispose();
       expect(closeCalls, 2);
@@ -1156,7 +1159,7 @@ void main() {
         connectionParameters: ConnectionParameters(
           connectionTimeout: const Duration(milliseconds: 50),
         ),
-        httpClientFactory: () => _AbortTrackingClient(
+        httpClientFactory: () => AbortTrackingClient(
           onAbort: () {
             requestAborted = true;
           },
@@ -1278,28 +1281,5 @@ class _CloseTrackingClient extends http.BaseClient {
   void close() {
     onClose();
     _inner.close();
-  }
-}
-
-class _AbortTrackingClient extends http.BaseClient {
-  _AbortTrackingClient({
-    required this.onAbort,
-    required this.onClose,
-  });
-
-  final void Function() onAbort;
-  final void Function() onClose;
-
-  @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    final abortable = request as http.Abortable;
-    await abortable.abortTrigger;
-    onAbort();
-    throw http.RequestAbortedException(request.url);
-  }
-
-  @override
-  void close() {
-    onClose();
   }
 }

--- a/cached_network_image/test/default_cache_manager_web_test.dart
+++ b/cached_network_image/test/default_cache_manager_web_test.dart
@@ -932,33 +932,44 @@ void main() {
       await manager.dispose();
     });
 
-    test('http.Client is closed after successful download', () async {
-      var clientClosed = false;
+    test('http.Client is reused across downloads and closed by dispose',
+        () async {
+      var factoryCalls = 0;
+      var closeCalls = 0;
       final manager = DefaultCacheManager(
         hiveInstance: testHive,
         httpClientFactory: () {
+          factoryCalls++;
           final mock = http_testing.MockClient(
             (request) async => http.Response('ok', 200),
           );
           return _CloseTrackingClient(mock, onClose: () {
-            clientClosed = true;
+            closeCalls++;
           });
         },
       );
 
+      expect(factoryCalls, 0);
+
       await manager
-          .getFileStream('https://example.com/web-client-ok.png')
+          .getFileStream('https://example.com/web-client-first.png')
+          .toList();
+      await manager
+          .getFileStream('https://example.com/web-client-second.png')
           .toList();
 
-      expect(clientClosed, isTrue,
-          reason: 'http.Client must be closed after download');
+      expect(factoryCalls, 1);
+      expect(closeCalls, 0);
 
-      await manager.emptyCache();
       await manager.dispose();
+      expect(closeCalls, 1);
+
+      await manager.dispose();
+      expect(closeCalls, 1);
     });
 
-    test('http.Client is closed after HTTP error', () async {
-      var clientClosed = false;
+    test('http.Client remains open after HTTP error until dispose', () async {
+      var closeCalls = 0;
       final manager = DefaultCacheManager(
         hiveInstance: testHive,
         httpClientFactory: () {
@@ -966,7 +977,7 @@ void main() {
             (request) async => http.Response('fail', 500),
           );
           return _CloseTrackingClient(mock, onClose: () {
-            clientClosed = true;
+            closeCalls++;
           });
         },
       );
@@ -977,10 +988,44 @@ void main() {
             .toList();
       } on Object catch (_) {}
 
-      expect(clientClosed, isTrue,
-          reason: 'http.Client must be closed even on error');
+      expect(closeCalls, 0);
 
       await manager.dispose();
+      expect(closeCalls, 1);
+    });
+
+    test('download after dispose creates a new http.Client', () async {
+      var factoryCalls = 0;
+      var closeCalls = 0;
+      final manager = DefaultCacheManager(
+        hiveInstance: testHive,
+        httpClientFactory: () {
+          factoryCalls++;
+          return _CloseTrackingClient(
+            http_testing.MockClient(
+              (request) async => http.Response('ok', 200),
+            ),
+            onClose: () {
+              closeCalls++;
+            },
+          );
+        },
+      );
+
+      await manager
+          .getFileStream('https://example.com/web-before-dispose.png')
+          .toList();
+      await manager.dispose();
+
+      await manager
+          .getFileStream('https://example.com/web-after-dispose.png')
+          .toList();
+
+      expect(factoryCalls, 2);
+      expect(closeCalls, 1);
+
+      await manager.dispose();
+      expect(closeCalls, 2);
     });
   });
 
@@ -1101,7 +1146,8 @@ void main() {
       expect(fileInfos.first.source.name, 'Online');
     });
 
-    test('client is closed even when connectionTimeout fires', () async {
+    test('client remains open after connection timeout until dispose',
+        () async {
       var clientClosed = false;
 
       manager = DefaultCacheManager(
@@ -1128,8 +1174,9 @@ void main() {
             .toList();
       } on Object catch (_) {}
 
-      expect(clientClosed, isTrue,
-          reason: 'http.Client must be closed even on timeout');
+      expect(clientClosed, isFalse);
+      await manager.dispose();
+      expect(clientClosed, isTrue);
     });
   });
 

--- a/cached_network_image/test/interceptor/http_interceptor_test.dart
+++ b/cached_network_image/test/interceptor/http_interceptor_test.dart
@@ -195,10 +195,21 @@ void main() {
     test('replaces response body — downstream gets replaced bytes', () async {
       final original = Uint8List.fromList([0, 1, 2, 3]);
       final replacement = _pngBytes;
+      var originalBodyCanceled = false;
 
-      final mockClient = http_testing.MockClient((request) async {
-        return http.Response.bytes(original, 200);
-      });
+      final mockClient = http_testing.MockClient.streaming(
+        (request, bodyStream) async {
+          late final StreamController<List<int>> controller;
+          controller = StreamController<List<int>>(
+            onCancel: () async {
+              originalBodyCanceled = true;
+              await controller.close();
+            },
+          );
+          controller.add(original);
+          return http.StreamedResponse(controller.stream, 200);
+        },
+      );
 
       final interceptor = _ResponseReplacingInterceptor(replacement);
       final manager = DefaultCacheManager(
@@ -211,6 +222,7 @@ void main() {
 
       final writtenBytes = await info.file.readAsBytes();
       expect(writtenBytes, replacement);
+      expect(originalBodyCanceled, isTrue);
     });
 
     test('next() passes through — original response is used', () async {

--- a/cached_network_image/test/leak_test.dart
+++ b/cached_network_image/test/leak_test.dart
@@ -131,37 +131,46 @@ void main() {
   });
 
   // ===========================================================================
-  // 2. http.Client closure in _downloadFile
+  // 2. Shared http.Client lifecycle
   // ===========================================================================
-  group('Leak: http.Client closure', () {
-    test('client.close() called after successful download', () async {
-      var clientClosed = false;
+  group('Leak: shared http.Client lifecycle', () {
+    test('client is reused across downloads and closed by dispose', () async {
+      var factoryCalls = 0;
+      var closeCalls = 0;
 
       final manager = DefaultCacheManager(
         httpClientFactory: () {
+          factoryCalls++;
           final mock = http_testing.MockClient(
             (request) async => http.Response('ok', 200),
           );
-          // Wrap to detect close
           return _CloseTrackingClient(mock, onClose: () {
-            clientClosed = true;
+            closeCalls++;
           });
         },
       );
 
+      expect(factoryCalls, 0);
+
       await manager
-          .getFileStream('https://example.com/client-close-success.png')
+          .getFileStream('https://example.com/client-reuse-first.png')
+          .toList();
+      await manager
+          .getFileStream('https://example.com/client-reuse-second.png')
           .toList();
 
-      expect(clientClosed, isTrue,
-          reason: 'http.Client must be closed after successful download');
+      expect(factoryCalls, 1);
+      expect(closeCalls, 0);
 
-      await manager.emptyCache();
       await manager.dispose();
+      expect(closeCalls, 1);
+
+      await manager.dispose();
+      expect(closeCalls, 1);
     });
 
-    test('client.close() called after HTTP error', () async {
-      var clientClosed = false;
+    test('client remains open after HTTP error until dispose', () async {
+      var closeCalls = 0;
 
       final manager = DefaultCacheManager(
         httpClientFactory: () {
@@ -169,7 +178,7 @@ void main() {
             (request) async => http.Response('fail', 500),
           );
           return _CloseTrackingClient(mock, onClose: () {
-            clientClosed = true;
+            closeCalls++;
           });
         },
       );
@@ -180,14 +189,14 @@ void main() {
             .toList();
       } on Object catch (_) {}
 
-      expect(clientClosed, isTrue,
-          reason: 'http.Client must be closed even on HTTP error');
+      expect(closeCalls, 0);
 
       await manager.dispose();
+      expect(closeCalls, 1);
     });
 
-    test('client.close() called when send() throws', () async {
-      var clientClosed = false;
+    test('client remains open when send throws until dispose', () async {
+      var closeCalls = 0;
 
       final manager = DefaultCacheManager(
         httpClientFactory: () {
@@ -196,7 +205,7 @@ void main() {
                 throw const io.SocketException('Connection refused'),
           );
           return _CloseTrackingClient(mock, onClose: () {
-            clientClosed = true;
+            closeCalls++;
           });
         },
       );
@@ -207,10 +216,43 @@ void main() {
             .toList();
       } on Object catch (_) {}
 
-      expect(clientClosed, isTrue,
-          reason: 'http.Client must be closed even when send() throws');
+      expect(closeCalls, 0);
 
       await manager.dispose();
+      expect(closeCalls, 1);
+    });
+
+    test('download after dispose creates a new client', () async {
+      var factoryCalls = 0;
+      var closeCalls = 0;
+      final manager = DefaultCacheManager(
+        httpClientFactory: () {
+          factoryCalls++;
+          return _CloseTrackingClient(
+            http_testing.MockClient(
+              (request) async => http.Response('ok', 200),
+            ),
+            onClose: () {
+              closeCalls++;
+            },
+          );
+        },
+      );
+
+      await manager
+          .getFileStream('https://example.com/client-before-dispose.png')
+          .toList();
+      await manager.dispose();
+
+      await manager
+          .getFileStream('https://example.com/client-after-dispose.png')
+          .toList();
+
+      expect(factoryCalls, 2);
+      expect(closeCalls, 1);
+
+      await manager.dispose();
+      expect(closeCalls, 2);
     });
   });
 

--- a/cached_network_image/test/leak_test.dart
+++ b/cached_network_image/test/leak_test.dart
@@ -13,6 +13,7 @@ import 'dart:ui' as ui;
 import 'package:cached_network_image_ce/cached_network_image.dart'
     hide DefaultCacheManager;
 import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
+import 'package:cached_network_image_ce/src/cache/shared_http_client.dart';
 import 'package:cached_network_image_ce/src/image_provider/_image_loader.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -222,7 +223,7 @@ void main() {
       expect(closeCalls, 1);
     });
 
-    test('download after dispose creates a new client', () async {
+    test('download after dispose creates and closes a new client', () async {
       var factoryCalls = 0;
       var closeCalls = 0;
       final manager = DefaultCacheManager(
@@ -249,10 +250,48 @@ void main() {
           .toList();
 
       expect(factoryCalls, 2);
-      expect(closeCalls, 1);
+      expect(closeCalls, 2);
 
       await manager.dispose();
       expect(closeCalls, 2);
+    });
+
+    test('post-dispose client closes after its last active download', () async {
+      var closeCalls = 0;
+      var sendCalls = 0;
+      final firstResponse = Completer<http.StreamedResponse>();
+      final secondResponse = Completer<http.StreamedResponse>();
+      final client = SharedHttpClient(
+        () => _CloseTrackingClient(
+          http_testing.MockClient.streaming((request, bodyStream) {
+            sendCalls++;
+            return sendCalls == 1
+                ? firstResponse.future
+                : secondResponse.future;
+          }),
+          onClose: () {
+            closeCalls++;
+          },
+        ),
+      );
+      client.dispose();
+
+      final firstSend = client.send(uri: Uri.parse('https://example.com/one'));
+      final secondSend = client.send(uri: Uri.parse('https://example.com/two'));
+
+      firstResponse.complete(
+        http.StreamedResponse(const Stream.empty(), 200),
+      );
+      final first = await firstSend;
+      first.release();
+      expect(closeCalls, 0);
+
+      secondResponse.complete(
+        http.StreamedResponse(const Stream.empty(), 200),
+      );
+      final second = await secondSend;
+      second.release();
+      expect(closeCalls, 1);
     });
   });
 

--- a/cached_network_image/test/support/http_clients.dart
+++ b/cached_network_image/test/support/http_clients.dart
@@ -1,0 +1,24 @@
+import 'package:http/http.dart' as http;
+
+class AbortTrackingClient extends http.BaseClient {
+  AbortTrackingClient({
+    required this.onAbort,
+    required this.onClose,
+  });
+
+  final void Function() onAbort;
+  final void Function() onClose;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final abortable = request as http.Abortable;
+    await abortable.abortTrigger;
+    onAbort();
+    throw http.RequestAbortedException(request.url);
+  }
+
+  @override
+  void close() {
+    onClose();
+  }
+}


### PR DESCRIPTION
## Description

Reuse a single lazily created `http.Client` for all cache-miss downloads handled by the same `DefaultCacheManager` instance on IO and web.

Previously, `_downloadFile()` created and closed a new client for every download. This discarded the client's connection pool after each request and prevented TCP/TLS connection reuse, adding avoidable latency and resource usage in image-heavy lists.

This change:

- lazily creates one shared client through the existing `httpClientFactory`;
- reuses it across successful downloads and request failures;
- centralizes the shared lifecycle and request-local timeout behavior for IO and web;
- closes the current client in `dispose()` while keeping the manager reusable;
- closes any client created after disposal as soon as its last active response is released, avoiding a lifecycle leak;
- uses a request-local `AbortableRequest` for connection deadlines, so a timeout cancels only that request while preserving `TimeoutException` semantics;
- cancels unused response streams when a response is rejected or replaced, with a single clear owner for each cancellation;
- preserves the existing public API and interceptor behavior.

Concurrent downloads for the same cache key are intentionally outside the scope of this PR.

### Validation

- `dart analyze` — no issues found
- `flutter test` — all 302 tests passed
- lifecycle tests cover lazy creation, reuse across downloads, HTTP/send/timeout failures, repeated disposal, recreation after disposal, and closing post-disposal clients after their final active response
- timeout tests cover request-local cancellation on IO and web, shared-client isolation, and response-body handling after headers
- response cleanup tests cover rejected HTTP responses and interceptor response replacement

## Related Issues

None.

## Checklist

- [x] I've read the contribution guidance available in the repository
- [x] All existing tests pass
- [x] I've added new tests for this performance and reliability fix
- [x] I've updated the CHANGELOG if applicable (not applicable; no unreleased section is currently open)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance**
  * Reused a shared HTTP client for downloads on both mobile and web to reduce repeated connection/setup overhead.

* **Reliability**
  * Improved handling for HTTP errors and interceptor response replacement to ensure unused response bodies are promptly cancelled.
  * Updated connection-timeout behavior to abort the in-flight request rather than leaving it running; refined disposal so in-progress downloads are aborted and the client is closed only when safe.

* **Tests**
  * Strengthened leak checks to verify correct shared-client reuse, close timing, and response-stream cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->