### PR TITLE
fix(cache): recover when eviction deletes a cached file mid-read

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.10.1] - 2026-08-26
+
+* **Fix:** `PathNotFoundException` when the background cleanup sweep deleted a cached file after `getFileFromCache` had already handed out its `FileInfo` but before the image was read. The sweep starts unawaited during initialization, so on cold start every first-frame load raced it. A cached file that disappears mid-read now falls back to a fresh download instead of throwing. Applies to the resize path too, which reads the separately-evictable original entry.
+* **Fix:** `getImageFile` removed its in-flight resize entry only after its stream completed, so abandoning that stream left every later call for the same key waiting on a stream that had already finished, and no image was ever delivered.
+* **Fix:** `putFile` now awaits its Hive metadata write instead of returning while the write is still unsequenced.
+* **Behaviour change:** The cleanup sweep skips entries served within the last 30 seconds, so an image still being loaded is not evicted out from under its reader. Skipped entries lose their place in the eviction order but not the size budget, so `maxNrOfCacheObjects` is still honoured.
+
+reported by [@aycasecr](https://github.com/aycasecr) — thanks! (PR #62)
+
 ## [4.10.0] - 2026-07-30
 
 * **Performance:** `DefaultCacheManager` now reuses a single HTTP client across downloads instead of creating and closing one per request, so connections can be kept alive between images.

--- a/cached_network_image/analysis_options.yaml
+++ b/cached_network_image/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml

--- a/cached_network_image/lib/src/cache/default_cache_manager.dart
+++ b/cached_network_image/lib/src/cache/default_cache_manager.dart
@@ -30,6 +30,11 @@ const _kDefaultMaxAge = Duration(days: 30);
 const _kDefaultMaxCacheObjects = 200;
 const _kDefaultStalePeriod = Duration(days: 7);
 const _kOrphanFileGracePeriod = Duration(minutes: 5);
+const _kServedEntryGracePeriod = Duration(seconds: 30);
+
+/// Size at which [DefaultCacheManager._recentlyServed] is swept for expired
+/// entries. Only a bound on bookkeeping, not on how many entries are guarded.
+const _kServedEntryPruneThreshold = 64;
 
 const _supportedFileNames = ['jpg', 'jpeg', 'png', 'tga', 'cur', 'ico'];
 
@@ -114,6 +119,14 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
   Box<Map>? _cacheBox;
   String? _cacheDir;
+
+  /// Box keys handed out to a caller recently, with the time they were served.
+  ///
+  /// A [FileInfo] only carries a path, so the caller reads the file some time
+  /// after [getFileFromCache] returns. Evicting one of these in the meantime
+  /// leaves the caller holding a path to a file that no longer exists, so the
+  /// cleanup sweep leaves them alone for [_kServedEntryGracePeriod].
+  final Map<String, DateTime> _recentlyServed = {};
 
   /// Guards [_doInit] so that concurrent callers (e.g. multiple images
   /// loading at the same time on cold start) share the same init future.
@@ -610,10 +623,32 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     }
 
     final localFile = const LocalFileSystem().file(filePath);
+    _markServed(_sanitizeBoxKey(key));
     unawaited(_touchEntry(key));
     return FileInfo(
         localFile, FileSource.Cache, metadata.validTill, metadata.url);
   }
+
+  /// Records that [sanitizedKey] was handed to a caller, and drops entries
+  /// that have outlived the grace period once the map has grown enough to be
+  /// worth sweeping.
+  void _markServed(String sanitizedKey) {
+    final now = DateTime.now();
+    _recentlyServed[sanitizedKey] = now;
+    if (_recentlyServed.length > _kServedEntryPruneThreshold) {
+      _pruneRecentlyServed(now);
+    }
+  }
+
+  void _pruneRecentlyServed(DateTime now) {
+    _recentlyServed.removeWhere(
+      (_, servedAt) => now.difference(servedAt) >= _kServedEntryGracePeriod,
+    );
+  }
+
+  /// Number of entries currently protected from eviction. Test-only.
+  @visibleForTesting
+  int get debugRecentlyServedCount => _recentlyServed.length;
 
   /// Updates the [touchedAt] timestamp for [key] in the cache box.
   ///
@@ -669,7 +704,7 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
     await file.writeAsBytes(fileBytes);
 
     final validTill = DateTime.now().add(maxAge);
-    _cacheBox!.put(
+    await _cacheBox!.put(
         _sanitizeBoxKey(key),
         CacheEntryMetadata(
           url: url,
@@ -753,16 +788,26 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       // Ignore errors when closing Hive (e.g. residual lock file already gone).
     }
 
+    _recentlyServed.clear();
     _cacheBox = null;
     _cacheDir = null;
     _initCompleter = null;
     _cleanupFuture = null;
   }
 
+  /// Runs the eviction sweep synchronously, for tests that need to observe
+  /// its result without racing the unawaited sweep started by [_doInit].
+  @visibleForTesting
+  Future<void> debugRunCleanup() async {
+    await _ensureInitialized();
+    await _cleanupOldFiles();
+  }
+
   /// Clean up files that haven't been used in a while.
   Future<void> _cleanupOldFiles() async {
     try {
       final now = DateTime.now();
+      _pruneRecentlyServed(now);
       final entries = <MapEntry<String, CacheEntryMetadata>>[];
 
       for (final key in _cacheBox!.keys.toList()) {
@@ -779,12 +824,9 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
 
       // Remove expired entries
       for (final entry in entries) {
-        if (entry.value.validTill.isBefore(now)) {
-          final file = io.File(_cacheFilePath(entry.value.relativePath));
-          if (await file.exists()) {
-            await file.delete();
-          }
-          await _cacheBox!.delete(entry.key);
+        if (entry.value.validTill.isBefore(now) &&
+            !_recentlyServed.containsKey(entry.key)) {
+          await _evictEntry(entry);
         }
       }
 
@@ -795,13 +837,14 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         );
 
         final toRemove = sortedEntries.length - maxNrOfCacheObjects;
-        for (var i = 0; i < toRemove; i++) {
-          final entry = sortedEntries[i];
-          final file = io.File(_cacheFilePath(entry.value.relativePath));
-          if (await file.exists()) {
-            await file.delete();
-          }
-          await _cacheBox!.delete(entry.key);
+        var removed = 0;
+        for (final entry in sortedEntries) {
+          if (removed >= toRemove) break;
+          // Skip rather than stop, so a recently served entry costs the cache
+          // its place in the eviction order but not the size budget.
+          if (_recentlyServed.containsKey(entry.key)) continue;
+          await _evictEntry(entry);
+          removed++;
         }
       }
     } on Object catch (e) {
@@ -810,6 +853,15 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
         CacheManagerLogLevel.warning,
       );
     }
+  }
+
+  /// Deletes the cached file for [entry] and then its metadata record.
+  Future<void> _evictEntry(MapEntry<String, CacheEntryMetadata> entry) async {
+    final file = io.File(_cacheFilePath(entry.value.relativePath));
+    if (await file.exists()) {
+      await file.delete();
+    }
+    await _cacheBox!.delete(entry.key);
   }
 
   Future<void> _deleteOrphanedCacheFiles(
@@ -890,8 +942,17 @@ class DefaultCacheManager extends CacheManager with ImageCacheManager {
       ).asBroadcastStream();
       _runningResizes[resizedKey] = runningResize;
     }
-    yield* runningResize;
-    _runningResizes.remove(resizedKey);
+    try {
+      yield* runningResize;
+    } finally {
+      // A consumer can abandon this stream early (for example the image
+      // loader refetching after a cached file was evicted mid-read). Without
+      // this, the entry would outlive its now-completed broadcast stream and
+      // every later call for the same key would attach to it and never emit.
+      if (_runningResizes[resizedKey] == runningResize) {
+        _runningResizes.remove(resizedKey);
+      }
+    }
   }
 
   Stream<FileResponse> _fetchedResizedFile(

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show PathNotFoundException;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 import 'dart:ui';
@@ -92,51 +93,90 @@ class ImageLoader implements platform.ImageLoader {
           'CacheManager needs to be an ImageCacheManager. maxWidth and '
           'maxHeight will be ignored when a normal CacheManager is used.');
 
-      final stream = cacheManager is ImageCacheManager
-          ? cacheManager.getImageFile(
-              url,
-              maxHeight: maxHeight,
-              maxWidth: maxWidth,
-              withProgress: true,
-              headers: headers,
-              key: cacheKey,
-            )
-          : cacheManager.getFileStream(
-              url,
-              withProgress: true,
-              headers: headers,
-              key: cacheKey,
-            );
+      // A cache manager can delete a cached file during its own eviction
+      // sweep after it has already handed out the FileInfo pointing at it,
+      // which leaves the read below throwing PathNotFoundException for a file
+      // the cache reported as valid. Fetching again turns that into an
+      // ordinary cache miss and a fresh download. One extra attempt only, so
+      // a genuinely unreadable cache directory cannot spin.
+      var mayRefetch = true;
+      var refetch = true;
 
-      await for (final result in stream) {
-        if (result is DownloadProgress) {
-          chunkEvents.add(
-            ImageChunkEvent(
-              cumulativeBytesLoaded: result.downloaded,
-              expectedTotalBytes: result.totalSize,
-            ),
-          );
-        }
-        if (result is FileInfo) {
-          final file = result.file;
-          final bytes = await file.readAsBytes();
-          final unsupportedFormat =
-              ImageFormatDetector.detectUnsupportedFormat(bytes);
-          if (unsupportedFormat != null) {
-            throw UnsupportedImageFormatException(
-              bytes: bytes,
-              url: url,
-              detectedFormat: unsupportedFormat,
-            );
+      while (refetch) {
+        refetch = false;
+
+        final stream = cacheManager is ImageCacheManager
+            ? cacheManager.getImageFile(
+                url,
+                maxHeight: maxHeight,
+                maxWidth: maxWidth,
+                withProgress: true,
+                headers: headers,
+                key: cacheKey,
+              )
+            : cacheManager.getFileStream(
+                url,
+                withProgress: true,
+                headers: headers,
+                key: cacheKey,
+              );
+
+        // Set when the read below already ruled a refetch out, so the handler
+        // around the loop does not second-guess that as the error unwinds.
+        var refetchDeclined = false;
+        try {
+          await for (final result in stream) {
+            if (result is DownloadProgress) {
+              chunkEvents.add(
+                ImageChunkEvent(
+                  cumulativeBytesLoaded: result.downloaded,
+                  expectedTotalBytes: result.totalSize,
+                ),
+              );
+            }
+            if (result is FileInfo) {
+              final file = result.file;
+              Uint8List? bytes;
+              try {
+                bytes = await file.readAsBytes();
+              } on PathNotFoundException {
+                // Only a cached file can be evicted out from under us. A
+                // missing file on a just-downloaded result is a different
+                // defect and must stay visible.
+                if (!mayRefetch || result.source != FileSource.Cache) {
+                  refetchDeclined = true;
+                  rethrow;
+                }
+                refetch = true;
+              }
+              if (bytes == null) break;
+              final unsupportedFormat =
+                  ImageFormatDetector.detectUnsupportedFormat(bytes);
+              if (unsupportedFormat != null) {
+                throw UnsupportedImageFormatException(
+                  bytes: bytes,
+                  url: url,
+                  detectedFormat: unsupportedFormat,
+                );
+              }
+              final ui.Codec decoded;
+              try {
+                decoded = await decode(bytes);
+              } catch (_) {
+                throw UnsupportedImageFormatException(bytes: bytes, url: url);
+              }
+              yield decoded;
+            }
           }
-          final ui.Codec decoded;
-          try {
-            decoded = await decode(bytes);
-          } catch (_) {
-            throw UnsupportedImageFormatException(bytes: bytes, url: url);
-          }
-          yield decoded;
+        } on PathNotFoundException {
+          // The same race, reached while the cache manager itself read a
+          // cached file: resizing reads the original entry, which is
+          // separately evictable.
+          if (!mayRefetch || refetchDeclined) rethrow;
+          refetch = true;
         }
+
+        if (refetch) mayRefetch = false;
       }
     } on Object catch (error, stackTrace) {
       // Depending on where the exception was thrown, the image cache may not

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.10.0
+version: 4.10.1
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -8,9 +8,8 @@ import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
 import 'package:cached_network_image_ce/src/image_provider/_image_loader.dart'
     as io_loader;
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
-import 'package:file/file.dart' show File;
-import 'package:flutter/widgets.dart' show ImageChunkEvent;
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show ImageChunkEvent;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
 // ignore: implementation_imports
@@ -18,6 +17,7 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 
+import 'fake_cache_manager.dart';
 import 'image_data.dart';
 import 'support/http_clients.dart';
 
@@ -41,93 +41,6 @@ class _CorruptPayloadAdapter extends TypeAdapter<_CorruptPayload> {
   @override
   void write(BinaryWriter writer, _CorruptPayload obj) =>
       writer.writeString(obj.data);
-}
-
-/// Deletes the cached file out from under the first cache-sourced [FileInfo]
-/// it forwards, reproducing an eviction sweep that lands between the cache
-/// manager yielding the file and the consumer reading it.
-class _EvictBeforeReadManager extends CacheManager with ImageCacheManager {
-  _EvictBeforeReadManager(this._inner);
-
-  final DefaultCacheManager _inner;
-
-  int evictions = 0;
-
-  @override
-  Stream<FileResponse> getImageFile(
-    String url, {
-    String? key,
-    Map<String, String>? headers,
-    bool withProgress = false,
-    int? maxHeight,
-    int? maxWidth,
-  }) async* {
-    final stream = _inner.getImageFile(
-      url,
-      key: key,
-      headers: headers,
-      withProgress: withProgress,
-      maxHeight: maxHeight,
-      maxWidth: maxWidth,
-    );
-    await for (final response in stream) {
-      if (response is FileInfo &&
-          response.source == FileSource.Cache &&
-          evictions == 0) {
-        evictions++;
-        io.File(response.file.path).deleteSync();
-      }
-      yield response;
-    }
-  }
-
-  @override
-  Stream<FileResponse> getFileStream(
-    String url, {
-    String? key,
-    Map<String, String>? headers,
-    bool withProgress = false,
-  }) =>
-      _inner.getFileStream(
-        url,
-        key: key,
-        headers: headers,
-        withProgress: withProgress,
-      );
-
-  @override
-  Future<FileInfo?> getFileFromCache(
-    String key, {
-    bool ignoreMemCache = false,
-  }) =>
-      _inner.getFileFromCache(key, ignoreMemCache: ignoreMemCache);
-
-  @override
-  Future<File> putFile(
-    String url,
-    List<int> fileBytes, {
-    String? key,
-    String? eTag,
-    Duration maxAge = const Duration(days: 30),
-    String fileExtension = 'file',
-  }) =>
-      _inner.putFile(
-        url,
-        fileBytes,
-        key: key,
-        eTag: eTag,
-        maxAge: maxAge,
-        fileExtension: fileExtension,
-      );
-
-  @override
-  Future<void> removeFile(String key) => _inner.removeFile(key);
-
-  @override
-  Future<void> emptyCache() => _inner.emptyCache();
-
-  @override
-  Future<void> dispose() => _inner.dispose();
 }
 
 void main() {
@@ -1755,7 +1668,7 @@ void main() {
       // Reproduce the production interleaving: the eviction sweep deletes the
       // file after getFileFromCache has handed out the FileInfo but before the
       // image loader reads it.
-      final evicting = _EvictBeforeReadManager(inner);
+      final evicting = EvictBeforeReadManager(inner);
 
       final chunkEvents = StreamController<ImageChunkEvent>()
         ..stream.listen((_) {});
@@ -1797,7 +1710,7 @@ void main() {
       await inner.getFileStream(url).toList();
       expect(requests, 1);
 
-      final evicting = _EvictBeforeReadManager(inner);
+      final evicting = EvictBeforeReadManager(inner);
 
       final chunkEvents = StreamController<ImageChunkEvent>()
         ..stream.listen((_) {});
@@ -1842,7 +1755,7 @@ void main() {
       await inner.putFile(url, kTransparentImage,
           maxAge: Duration.zero, fileExtension: 'png');
 
-      final evicting = _EvictBeforeReadManager(inner);
+      final evicting = EvictBeforeReadManager(inner);
 
       final chunkEvents = StreamController<ImageChunkEvent>()
         ..stream.listen((_) {});

--- a/cached_network_image/test/default_cache_manager_test.dart
+++ b/cached_network_image/test/default_cache_manager_test.dart
@@ -1,10 +1,15 @@
 import 'dart:async';
 import 'dart:io' as io;
+import 'dart:ui' as ui;
 
 import 'package:cached_network_image_ce/cached_network_image.dart'
     show LruCleanupStrategy, TtlCleanupStrategy;
 import 'package:cached_network_image_ce/src/cache/default_cache_manager.dart';
+import 'package:cached_network_image_ce/src/image_provider/_image_loader.dart'
+    as io_loader;
 import 'package:cached_network_image_platform_interface_ce/cached_network_image_platform_interface_ce.dart';
+import 'package:file/file.dart' show File;
+import 'package:flutter/widgets.dart' show ImageChunkEvent;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce/hive.dart';
@@ -13,6 +18,7 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart' as http_testing;
 
+import 'image_data.dart';
 import 'support/http_clients.dart';
 
 /// A custom object that forces Hive to write a user-defined typeId into
@@ -35,6 +41,93 @@ class _CorruptPayloadAdapter extends TypeAdapter<_CorruptPayload> {
   @override
   void write(BinaryWriter writer, _CorruptPayload obj) =>
       writer.writeString(obj.data);
+}
+
+/// Deletes the cached file out from under the first cache-sourced [FileInfo]
+/// it forwards, reproducing an eviction sweep that lands between the cache
+/// manager yielding the file and the consumer reading it.
+class _EvictBeforeReadManager extends CacheManager with ImageCacheManager {
+  _EvictBeforeReadManager(this._inner);
+
+  final DefaultCacheManager _inner;
+
+  int evictions = 0;
+
+  @override
+  Stream<FileResponse> getImageFile(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+    int? maxHeight,
+    int? maxWidth,
+  }) async* {
+    final stream = _inner.getImageFile(
+      url,
+      key: key,
+      headers: headers,
+      withProgress: withProgress,
+      maxHeight: maxHeight,
+      maxWidth: maxWidth,
+    );
+    await for (final response in stream) {
+      if (response is FileInfo &&
+          response.source == FileSource.Cache &&
+          evictions == 0) {
+        evictions++;
+        io.File(response.file.path).deleteSync();
+      }
+      yield response;
+    }
+  }
+
+  @override
+  Stream<FileResponse> getFileStream(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+  }) =>
+      _inner.getFileStream(
+        url,
+        key: key,
+        headers: headers,
+        withProgress: withProgress,
+      );
+
+  @override
+  Future<FileInfo?> getFileFromCache(
+    String key, {
+    bool ignoreMemCache = false,
+  }) =>
+      _inner.getFileFromCache(key, ignoreMemCache: ignoreMemCache);
+
+  @override
+  Future<File> putFile(
+    String url,
+    List<int> fileBytes, {
+    String? key,
+    String? eTag,
+    Duration maxAge = const Duration(days: 30),
+    String fileExtension = 'file',
+  }) =>
+      _inner.putFile(
+        url,
+        fileBytes,
+        key: key,
+        eTag: eTag,
+        maxAge: maxAge,
+        fileExtension: fileExtension,
+      );
+
+  @override
+  Future<void> removeFile(String key) => _inner.removeFile(key);
+
+  @override
+  Future<void> emptyCache() => _inner.emptyCache();
+
+  @override
+  Future<void> dispose() => _inner.dispose();
 }
 
 void main() {
@@ -1642,6 +1735,143 @@ void main() {
       expect(receivedAuth, 'Bearer xyz');
     });
 
+    test('recovers when a cached file is evicted before the image is read',
+        () async {
+      var requests = 0;
+      final inner = DefaultCacheManager(
+        httpClientFactory: () => http_testing.MockClient((request) async {
+          requests++;
+          return http.Response.bytes(kTransparentImage, 200);
+        }),
+      );
+      manager = inner;
+
+      const url = 'https://example.com/evicted-before-read.png';
+
+      // Prime the cache so the next load takes the cache-hit path.
+      await inner.getFileStream(url).toList();
+      expect(requests, 1);
+
+      // Reproduce the production interleaving: the eviction sweep deletes the
+      // file after getFileFromCache has handed out the FileInfo but before the
+      // image loader reads it.
+      final evicting = _EvictBeforeReadManager(inner);
+
+      final chunkEvents = StreamController<ImageChunkEvent>()
+        ..stream.listen((_) {});
+      final codecs = await io_loader.ImageLoader()
+          .loadImageAsync(
+            url,
+            null,
+            chunkEvents,
+            (ui.ImmutableBuffer buffer,
+                    {ui.TargetImageSizeCallback? getTargetSize}) async =>
+                ui.instantiateImageCodecFromBuffer(buffer),
+            evicting,
+            null,
+            null,
+            null,
+            ImageRenderMethodForWeb.HttpGet,
+            () {},
+          )
+          .toList()
+          .timeout(const Duration(seconds: 10));
+
+      expect(evicting.evictions, 1, reason: 'the race must have been staged');
+      expect(codecs, hasLength(1), reason: 'the image must still decode');
+      expect(requests, 2, reason: 'the refetch must have gone to the network');
+    });
+
+    test('recovers from eviction on the resize path too', () async {
+      var requests = 0;
+      final inner = DefaultCacheManager(
+        httpClientFactory: () => http_testing.MockClient((request) async {
+          requests++;
+          return http.Response.bytes(kTransparentImage, 200);
+        }),
+      );
+      manager = inner;
+
+      const url = 'https://example.com/evicted-resize-path.png';
+
+      await inner.getFileStream(url).toList();
+      expect(requests, 1);
+
+      final evicting = _EvictBeforeReadManager(inner);
+
+      final chunkEvents = StreamController<ImageChunkEvent>()
+        ..stream.listen((_) {});
+      final codecs = await io_loader.ImageLoader()
+          .loadImageAsync(
+            url,
+            null,
+            chunkEvents,
+            (ui.ImmutableBuffer buffer,
+                    {ui.TargetImageSizeCallback? getTargetSize}) async =>
+                ui.instantiateImageCodecFromBuffer(buffer),
+            evicting,
+            null,
+            1,
+            null,
+            ImageRenderMethodForWeb.HttpGet,
+            () {},
+          )
+          .toList()
+          .timeout(const Duration(seconds: 10));
+
+      expect(evicting.evictions, 1, reason: 'the race must have been staged');
+      expect(codecs, hasLength(1), reason: 'the image must still decode');
+    });
+
+    test('recovers when an expired cached file is evicted before the read',
+        () async {
+      var requests = 0;
+      final inner = DefaultCacheManager(
+        httpClientFactory: () => http_testing.MockClient((request) async {
+          requests++;
+          return http.Response.bytes(kTransparentImage, 200);
+        }),
+      );
+      manager = inner;
+
+      const url = 'https://example.com/evicted-expired.png';
+
+      // An already-expired entry makes _pushFileToStream emit the stale
+      // FileInfo and then carry on downloading, so the refetch happens while
+      // the first request is still in flight.
+      await inner.putFile(url, kTransparentImage,
+          maxAge: Duration.zero, fileExtension: 'png');
+
+      final evicting = _EvictBeforeReadManager(inner);
+
+      final chunkEvents = StreamController<ImageChunkEvent>()
+        ..stream.listen((_) {});
+      final codecs = await io_loader.ImageLoader()
+          .loadImageAsync(
+            url,
+            null,
+            chunkEvents,
+            (ui.ImmutableBuffer buffer,
+                    {ui.TargetImageSizeCallback? getTargetSize}) async =>
+                ui.instantiateImageCodecFromBuffer(buffer),
+            evicting,
+            null,
+            null,
+            null,
+            ImageRenderMethodForWeb.HttpGet,
+            () {},
+          )
+          .toList()
+          .timeout(const Duration(seconds: 10));
+
+      expect(evicting.evictions, 1, reason: 'the race must have been staged');
+      expect(codecs, isNotEmpty, reason: 'the image must still decode');
+      expect(requests, greaterThanOrEqualTo(1));
+
+      // Let any download abandoned by the refetch finish writing.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    });
+
     test('uses key parameter', () async {
       manager = DefaultCacheManager(
         httpClientFactory: () => http_testing.MockClient(
@@ -1695,6 +1925,111 @@ void main() {
   // ---- _cleanupOldFiles tests ----
 
   group('DefaultCacheManager._cleanupOldFiles', () {
+    test('does not evict an entry that was just served to a caller', () async {
+      final dir = io.Directory.systemTemp.createTempSync('evict_guard_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        maxNrOfCacheObjects: 2,
+        cacheDirectoryProvider: () async => dir,
+      );
+      addTearDown(() async {
+        try {
+          await manager.dispose();
+        } on Object catch (_) {}
+      });
+
+      // TtlCleanupStrategy evicts the earliest validTill first, so 'soonest'
+      // is the natural victim.
+      await manager.putFile('https://example.com/a.png', [1],
+          key: 'soonest', maxAge: const Duration(hours: 1));
+      await manager.putFile('https://example.com/b.png', [2],
+          key: 'middle', maxAge: const Duration(hours: 2));
+      await manager.putFile('https://example.com/c.png', [3],
+          key: 'latest', maxAge: const Duration(hours: 3));
+
+      // Serving it hands a file path to a caller that has not read it yet.
+      expect(await manager.getFileFromCache('soonest'), isNotNull);
+
+      await manager.debugRunCleanup();
+
+      expect(await manager.getFileFromCache('soonest'), isNotNull,
+          reason: 'an entry just handed out must not be evicted');
+      expect(await manager.getFileFromCache('middle'), isNull,
+          reason: 'the next eligible entry is evicted instead');
+      expect(await manager.getFileFromCache('latest'), isNotNull);
+    });
+
+    test('served-entry bookkeeping keeps live entries and clears on dispose',
+        () async {
+      final dir = io.Directory.systemTemp.createTempSync('served_bound_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        maxNrOfCacheObjects: 1000,
+        cacheDirectoryProvider: () async => dir,
+      );
+      addTearDown(() async {
+        try {
+          await manager.dispose();
+        } on Object catch (_) {}
+      });
+
+      for (var i = 0; i < 200; i++) {
+        await manager.putFile('https://example.com/$i.png', [i], key: 'k$i');
+        expect(await manager.getFileFromCache('k$i'), isNotNull);
+      }
+
+      // Everything here was served inside the grace period, so nothing can be
+      // dropped yet; the point is that the sweep runs and the map cannot grow
+      // without ever being revisited.
+      expect(manager.debugRecentlyServedCount, 200);
+
+      await manager.dispose();
+      expect(manager.debugRecentlyServedCount, 0);
+    });
+
+    test('still evicts down to maxNrOfCacheObjects when nothing was served',
+        () async {
+      final dir = io.Directory.systemTemp.createTempSync('evict_plain_');
+      addTearDown(() {
+        try {
+          dir.deleteSync(recursive: true);
+        } on Object catch (_) {}
+      });
+
+      final manager = DefaultCacheManager(
+        maxNrOfCacheObjects: 2,
+        cacheDirectoryProvider: () async => dir,
+      );
+      addTearDown(() async {
+        try {
+          await manager.dispose();
+        } on Object catch (_) {}
+      });
+
+      await manager.putFile('https://example.com/a.png', [1],
+          key: 'soonest', maxAge: const Duration(hours: 1));
+      await manager.putFile('https://example.com/b.png', [2],
+          key: 'middle', maxAge: const Duration(hours: 2));
+      await manager.putFile('https://example.com/c.png', [3],
+          key: 'latest', maxAge: const Duration(hours: 3));
+
+      await manager.debugRunCleanup();
+
+      expect(await manager.getFileFromCache('soonest'), isNull);
+      expect(await manager.getFileFromCache('middle'), isNotNull);
+      expect(await manager.getFileFromCache('latest'), isNotNull);
+    });
+
     test('removes expired entries during initialization', () async {
       // First, put an entry with zero stale period
       final manager1 = DefaultCacheManager(

--- a/cached_network_image/test/fake_cache_manager.dart
+++ b/cached_network_image/test/fake_cache_manager.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io' as io;
 import 'dart:typed_data';
 
 import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:file/file.dart' show File;
 import 'package:file/memory.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -189,4 +191,91 @@ class ExpectedData {
     required this.totalSize,
     required this.chunkSize,
   });
+}
+
+/// Deletes the cached file out from under the first cache-sourced [FileInfo]
+/// it forwards, reproducing an eviction sweep that lands between the cache
+/// manager yielding the file and the consumer reading it.
+class EvictBeforeReadManager extends CacheManager with ImageCacheManager {
+  EvictBeforeReadManager(this._inner);
+
+  final ImageCacheManager _inner;
+
+  int evictions = 0;
+
+  @override
+  Stream<FileResponse> getImageFile(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+    int? maxHeight,
+    int? maxWidth,
+  }) async* {
+    final stream = _inner.getImageFile(
+      url,
+      key: key,
+      headers: headers,
+      withProgress: withProgress,
+      maxHeight: maxHeight,
+      maxWidth: maxWidth,
+    );
+    await for (final response in stream) {
+      if (response is FileInfo &&
+          response.source == FileSource.Cache &&
+          evictions == 0) {
+        evictions++;
+        io.File(response.file.path).deleteSync();
+      }
+      yield response;
+    }
+  }
+
+  @override
+  Stream<FileResponse> getFileStream(
+    String url, {
+    String? key,
+    Map<String, String>? headers,
+    bool withProgress = false,
+  }) =>
+      _inner.getFileStream(
+        url,
+        key: key,
+        headers: headers,
+        withProgress: withProgress,
+      );
+
+  @override
+  Future<FileInfo?> getFileFromCache(
+    String key, {
+    bool ignoreMemCache = false,
+  }) =>
+      _inner.getFileFromCache(key, ignoreMemCache: ignoreMemCache);
+
+  @override
+  Future<File> putFile(
+    String url,
+    List<int> fileBytes, {
+    String? key,
+    String? eTag,
+    Duration maxAge = const Duration(days: 30),
+    String fileExtension = 'file',
+  }) =>
+      _inner.putFile(
+        url,
+        fileBytes,
+        key: key,
+        eTag: eTag,
+        maxAge: maxAge,
+        fileExtension: fileExtension,
+      );
+
+  @override
+  Future<void> removeFile(String key) => _inner.removeFile(key);
+
+  @override
+  Future<void> emptyCache() => _inner.emptyCache();
+
+  @override
+  Future<void> dispose() => _inner.dispose();
 }

--- a/cached_network_image/test/image_loader_test.dart
+++ b/cached_network_image/test/image_loader_test.dart
@@ -1,10 +1,12 @@
 // ignore_for_file: deprecated_member_use
 
 import 'dart:async';
+import 'dart:io' as io;
 import 'dart:ui' as ui;
 
 import 'package:cached_network_image_ce/cached_network_image.dart';
 import 'package:cached_network_image_ce/src/image_provider/_image_loader.dart';
+import 'package:file/local.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,6 +15,8 @@ import 'fake_cache_manager.dart';
 import 'image_data.dart';
 
 class MockBaseCacheManager extends Mock implements BaseCacheManager {}
+
+class MockImageCacheManager extends Mock implements ImageCacheManager {}
 
 void main() {
   late FakeCacheManager fakeCacheManager;
@@ -219,6 +223,152 @@ void main() {
       CachedNetworkImageProvider.defaultCacheManager = mockManager;
       expect(CachedNetworkImageProvider.defaultCacheManager, same(mockManager));
       CachedNetworkImageProvider.defaultCacheManager = original;
+    });
+  });
+
+  group('cache file evicted between yield and read', () {
+    late io.Directory tempDir;
+
+    setUp(() {
+      tempDir = io.Directory.systemTemp.createTempSync('image_loader_race_');
+    });
+
+    tearDown(() {
+      try {
+        tempDir.deleteSync(recursive: true);
+      } on Object catch (_) {
+        // Ignore
+      }
+    });
+
+    /// Writes [bytes] to a real file under [tempDir] and returns a cache-sourced
+    /// [FileInfo] pointing at it.
+    FileInfo cacheHit(String url, String name, List<int> bytes) {
+      final path = '${tempDir.path}/$name';
+      io.File(path).writeAsBytesSync(bytes);
+      return FileInfo(
+        const LocalFileSystem().file(path),
+        FileSource.Cache,
+        DateTime.now().add(const Duration(days: 1)),
+        url,
+      );
+    }
+
+    /// A [FileInfo] whose backing file has already been deleted, simulating an
+    /// eviction sweep that removed the file after the cache manager yielded it.
+    FileInfo evictedCacheHit(String url, String name) {
+      final info = cacheHit(url, name, kTransparentImage);
+      io.File(info.file.path).deleteSync();
+      return info;
+    }
+
+    Stream<ui.Codec> load(ImageCacheManager manager, String url) {
+      // Drain the chunk events: closing an unlistened StreamController never
+      // completes, which would hang _load's finally block.
+      final chunkEvents = StreamController<ImageChunkEvent>()
+        ..stream.listen((_) {});
+      return ImageLoader().loadImageAsync(
+        url,
+        null,
+        chunkEvents,
+        (ui.ImmutableBuffer buffer,
+            {ui.TargetImageSizeCallback? getTargetSize}) async {
+          return ui.instantiateImageCodecFromBuffer(buffer);
+        },
+        manager,
+        null,
+        null,
+        null,
+        ImageRenderMethodForWeb.HttpGet,
+        () {},
+      );
+    }
+
+    test('recovers by refetching when the cached file has been deleted',
+        () async {
+      const url = 'https://example.com/evicted.png';
+      final manager = MockImageCacheManager();
+
+      var call = 0;
+      when(
+        () => manager.getImageFile(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+          maxHeight: any(named: 'maxHeight'),
+          maxWidth: any(named: 'maxWidth'),
+        ),
+      ).thenAnswer((_) {
+        call++;
+        return Stream<FileResponse>.value(
+          call == 1
+              ? evictedCacheHit(url, 'gone.png')
+              : cacheHit(url, 'fresh.png', kTransparentImage),
+        );
+      });
+
+      final codecs = await load(manager, url).toList();
+
+      expect(codecs, hasLength(1));
+      expect(call, 2, reason: 'should have refetched exactly once');
+    });
+
+    test('surfaces the error when the refetch is also missing', () async {
+      const url = 'https://example.com/always-evicted.png';
+      final manager = MockImageCacheManager();
+
+      var call = 0;
+      when(
+        () => manager.getImageFile(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+          maxHeight: any(named: 'maxHeight'),
+          maxWidth: any(named: 'maxWidth'),
+        ),
+      ).thenAnswer((_) {
+        call++;
+        return Stream<FileResponse>.value(
+          evictedCacheHit(url, 'gone$call.png'),
+        );
+      });
+
+      await expectLater(
+        load(manager, url),
+        emitsError(isA<io.PathNotFoundException>()),
+      );
+      expect(call, 2, reason: 'retry must be capped at one');
+    });
+
+    test('does not retry a freshly downloaded file that is missing', () async {
+      const url = 'https://example.com/online-missing.png';
+      final manager = MockImageCacheManager();
+
+      var call = 0;
+      when(
+        () => manager.getImageFile(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+          maxHeight: any(named: 'maxHeight'),
+          maxWidth: any(named: 'maxWidth'),
+        ),
+      ).thenAnswer((_) {
+        call++;
+        final gone = evictedCacheHit(url, 'online$call.png');
+        return Stream<FileResponse>.value(
+          FileInfo(gone.file, FileSource.Online, gone.validTill, url),
+        );
+      });
+
+      await expectLater(
+        load(manager, url),
+        emitsError(isA<io.PathNotFoundException>()),
+      );
+      expect(call, 1, reason: 'an Online result is a different bug; no retry');
     });
   });
 


### PR DESCRIPTION
Fixes #61 the PathNotFoundException reported for files under the package's own cache directory.

`_doInit()` launches `_cleanupOldFiles()` unawaited and `_ensureInitialized()` completes right after, so on cold start every first-frame read runs against a live eviction sweep.

`getFileFromCache()` checks `existsSync()` before handing out a `FileInfo`, but the bytes are read much later, in `_image_loader.dart`. Deleting the file in that gap throws for a file the cache just called valid.

Note the reporter's suggested fix (reordering the two deletes in the sweep) does not close this. `getFileFromCache()` already handles "file gone, record present" by clearing the record and reporting a miss, so reordering only trades it for "record gone, file present", which is equally safe. Delete order is not what matters; whether the file is deleted between yield and read is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading reliability when cached files are removed during access.
  * Automatically retries eligible cache-read failures once while preserving errors for repeated or download-related failures.
  * Prevented recently served files from being removed during cache cleanup.
  * Fixed cleanup of resized-image streams when access ends early.
  * Ensured cache metadata is saved before file operations complete.

* **Tests**
  * Added coverage for cache eviction races, retry behavior, cleanup protection, and disposal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->