### PR TITLE
fix(widget): don't let errorListener identity trigger a cache re-check

### DIFF
--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -360,10 +360,17 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
         oldWidget.maxHeightDiskCache != widget.maxHeightDiskCache ||
         oldWidget.imageRenderMethodForWeb != widget.imageRenderMethodForWeb ||
         oldWidget.scale != widget.scale ||
-        oldWidget.minimumGifFrameDuration != widget.minimumGifFrameDuration ||
-        oldWidget.errorListener != widget.errorListener;
+        oldWidget.minimumGifFrameDuration != widget.minimumGifFrameDuration;
 
-    if (imageConfigChanged) {
+    // `errorListener` is a callback, and most callers pass a new closure on
+    // every build (it can't reasonably be expected to stay identical across
+    // rebuilds). It must not feed into `imageConfigChanged`: doing so made
+    // every unrelated parent rebuild look like the image target changed,
+    // which reset the cache-hit optimistic state below and made the
+    // placeholder/fade flicker on every rebuild while the image was still
+    // loading (see #32). We still refresh the provider so it carries the
+    // latest listener, just without treating it as a "real" config change.
+    if (imageConfigChanged || oldWidget.errorListener != widget.errorListener) {
       _createImageProvider();
     }
 

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter/foundation.dart' show mapEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:octo_image/octo_image.dart';
@@ -355,7 +356,12 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
     final imageConfigChanged = oldWidget.imageUrl != widget.imageUrl ||
         oldWidget.cacheKey != widget.cacheKey ||
         oldWidget.cacheManager != widget.cacheManager ||
-        oldWidget.httpHeaders != widget.httpHeaders ||
+        // `Map` has no value equality, so `!=` here compared identity: a
+        // caller passing `httpHeaders: {...}` as an inline literal (there is
+        // no way to keep that reference stable across rebuilds either) hit
+        // the exact same flicker bug as `errorListener` below (#32), just
+        // through a different field.
+        !mapEquals(oldWidget.httpHeaders, widget.httpHeaders) ||
         oldWidget.maxWidthDiskCache != widget.maxWidthDiskCache ||
         oldWidget.maxHeightDiskCache != widget.maxHeightDiskCache ||
         oldWidget.imageRenderMethodForWeb != widget.imageRenderMethodForWeb ||

--- a/cached_network_image/test/cached_image_widget_test.dart
+++ b/cached_network_image/test/cached_image_widget_test.dart
@@ -421,6 +421,81 @@ void main() {
     });
 
     testWidgets(
+        'does not re-run the disk-cache pre-check on an unrelated rebuild '
+        'that only passes a new errorListener closure (#32)', (tester) async {
+      // Image is NOT yet in the disk cache (still "loading"), which is the
+      // scenario from the reported issue: every parent rebuild while the
+      // image is loading re-triggered the cache pre-check and, in doing so,
+      // hid the placeholder for a frame each time, causing a visible
+      // flicker.
+      var imageUrl = 'unrelated-rebuild-not-cached-test';
+      var cacheCheckCount = 0;
+      when(
+        () => cacheManager.getFileFromCache(
+          imageUrl,
+          ignoreMemCache: any(named: 'ignoreMemCache'),
+        ),
+      ).thenAnswer((_) async {
+        cacheCheckCount++;
+        return null;
+      });
+      cacheManager.returns(imageUrl, kTransparentImage);
+      var rebuildCount = 0;
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    CachedNetworkImage(
+                      imageUrl: imageUrl,
+                      cacheManager: cacheManager,
+                      // A fresh closure every build, like most real callers
+                      // pass (e.g. `errorListener: (e) { ... }` written
+                      // inline). This must not be mistaken for the image
+                      // target changing.
+                      errorListener: (error) {},
+                      // Deliberately not an indeterminate spinner: that would
+                      // keep an animation ticking forever once shown, which
+                      // would make pump/pumpAndSettle calls below hang for
+                      // reasons unrelated to what this test is checking.
+                      placeholder: (context, url) => const Text('loading'),
+                    ),
+                    TextButton(
+                      onPressed: () => setState(() => rebuildCount++),
+                      child: const Text('Unrelated setState'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      // Let the initial disk-cache pre-check resolve.
+      await tester.pump();
+      await tester.pump();
+      expect(cacheCheckCount, 1,
+          reason: 'Exactly one pre-check should run for the initial build');
+
+      // Simulate a parent doing repeated, unrelated setState calls (e.g. a
+      // streaming chat UI) while this image is still loading. Each rebuild
+      // passes a brand new `errorListener` closure, as above. None of these
+      // should trigger another disk-cache pre-check, since nothing about
+      // the image target actually changed.
+      for (var i = 0; i < 5; i++) {
+        await tester.tap(find.text('Unrelated setState'));
+        await tester.pump();
+        await tester.pump();
+      }
+      expect(cacheCheckCount, 1,
+          reason: 'Unrelated rebuilds must not re-trigger the disk-cache '
+              'pre-check (and the placeholder flicker that comes with it)');
+    });
+
+    testWidgets(
         'always shows placeholder when disablePlaceholderOnCacheHit is false',
         (tester) async {
       var imageUrl = 'always-placeholder-test';

--- a/cached_network_image/test/cached_image_widget_test.dart
+++ b/cached_network_image/test/cached_image_widget_test.dart
@@ -496,6 +496,75 @@ void main() {
     });
 
     testWidgets(
+        'does not re-run the disk-cache pre-check on an unrelated rebuild '
+        'that only passes a content-equal but new httpHeaders map (#68)',
+        (tester) async {
+      // Same class of bug as the errorListener case above, entered through
+      // `httpHeaders` instead: `Map` has no value equality, so comparing it
+      // with `!=` treats a fresh-but-equal map literal (the normal way to
+      // pass headers inline) as a real config change on every rebuild.
+      var imageUrl = 'unrelated-rebuild-headers-test';
+      var cacheCheckCount = 0;
+      when(
+        () => cacheManager.getFileFromCache(
+          imageUrl,
+          ignoreMemCache: any(named: 'ignoreMemCache'),
+        ),
+      ).thenAnswer((_) async {
+        cacheCheckCount++;
+        return null;
+      });
+      cacheManager.returns(imageUrl, kTransparentImage);
+      var rebuildCount = 0;
+
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return MaterialApp(
+              home: Scaffold(
+                body: Column(
+                  children: [
+                    CachedNetworkImage(
+                      imageUrl: imageUrl,
+                      cacheManager: cacheManager,
+                      // A fresh (but content-equal) map literal every build,
+                      // like most real callers pass (e.g.
+                      // `httpHeaders: {'Authorization': token}` written
+                      // inline). This must not be mistaken for the image
+                      // target changing. Deliberately not `const`: a const
+                      // map would be canonicalized to the same instance on
+                      // every build, which wouldn't exercise this bug.
+                      // ignore: prefer_const_literals_to_create_immutables
+                      httpHeaders: {'Authorization': 'token'},
+                      placeholder: (context, url) => const Text('loading'),
+                    ),
+                    TextButton(
+                      onPressed: () => setState(() => rebuildCount++),
+                      child: const Text('Unrelated setState'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(cacheCheckCount, 1,
+          reason: 'Exactly one pre-check should run for the initial build');
+
+      for (var i = 0; i < 5; i++) {
+        await tester.tap(find.text('Unrelated setState'));
+        await tester.pump();
+        await tester.pump();
+      }
+      expect(cacheCheckCount, 1,
+          reason: 'Unrelated rebuilds must not re-trigger the disk-cache '
+              'pre-check (and the placeholder flicker that comes with it)');
+    });
+
+    testWidgets(
         'always shows placeholder when disablePlaceholderOnCacheHit is false',
         (tester) async {
       var imageUrl = 'always-placeholder-test';


### PR DESCRIPTION
 `_CachedNetworkImageState.didUpdateWidget()` folds                                                                                                                                                                                                                                
  `oldWidget.errorListener != widget.errorListener` into `imageConfigChanged`.                                                                                                                                                                                                      
  `errorListener` is a callback, and most real call sites pass a new closure                                                                                                                                                                                                        
  literal on every build:                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                    
  CachedNetworkImage(                                                                                                                                                                                                                                                               
    imageUrl: url,                                                                                                                                                                                                                                                                  
    errorListener: (e) {                                                                                                                                                                                                                                                            
      // ...                                                                                                                                                                                                                                                                        
    },                                                                                                                                                                                                                                                                              
    ...                                                                                                                                                                                                                                                                             
  )                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                    
  There is no way for a caller to keep that reference stable across rebuilds,                                                                                                                                                                                                       
  so `oldWidget.errorListener != widget.errorListener` is effectively always                                                                                                                                                                                                        
  `true`.  

  Because `imageConfigChanged` also gates the `disablePlaceholderOnCacheHit`                                                                                                                                                                                                        
  logic, *any* unrelated ancestor `setState()` was making the widget think its                                                                                                                                                                                                      
  image target had changed. Each time that happened it reset                                                                                                                                                                                                                        
  `_skipPlaceholder = true` synchronously and re-ran `_preCheckCache()`. While                                                                                                                                                                                                      
  the image is still loading (not yet on disk), the pre-check keeps resolving                                                                                                                                                                                                       
  to "not cached yet" and flips `_skipPlaceholder` back to `false` — so the                                                                                                                                                                                                         
  placeholder/fade state was toggling on every single ancestor rebuild instead                                                                                                                                                                                                      
  of only on real load-progress events. In a screen that rebuilds frequently                                                                                                                                                                                                        
  while an image is loading (a streaming chat UI, a list with a ticking timer,                                                                                                                                                                                                      
  etc.), this is visible as the image flickering rapidly, unrelated to the                                                                                                                                                                                                          
  actual download progress.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                    
  The fix excludes `errorListener` from `imageConfigChanged` (matching how the                                                                                                                                                                                                      
  other callback-typed fields — `imageBuilder`, `placeholder`,                                                                                                                                                                                                                      
  `progressIndicatorBuilder`, `errorBuilder` — are already excluded from it).                                                                                                                                                                                                       
  The provider is still recreated whenever `errorListener` changes, so it keeps                                                                                                                                                                                                     
  referencing the latest listener; it's just no longer treated as a "real"                                                                                                                                                                                                          
  image-target change for the disk-cache pre-check.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                    
  ## Related Issues                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                    
  Fixes #32                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                    
  ## Checklist                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                    
  - [x] I've read the Contributor Guide                                                                                                                                                                                                                                             
  - [x] All existing tests pass                                                                                                                                                                                                                                                     
  - [x] I've added new tests for any new features or bug fixes                                                                                                                                                                                                                      
  - [x] I've updated the CHANGELOG if applicable — not touched; based on prior                                                                                                                                                                                                      
        merged PRs, the CHANGELOG/version bump appears to be handled by the                                                                                                                                                                                                         
        maintainer in a separate release commit  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented placeholder and fade flicker when images rebuild with equivalent HTTP headers.
  * Avoided unnecessary repeated cache checks during unrelated parent rebuilds.

* **Tests**
  * Added coverage confirming cached images perform only one cache check across repeated rebuilds, even when a new equivalent headers map is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->