### PR TITLE
Add preCache static method for cache warming

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Shipping something with it? [Open a PR](https://github.com/Erengun/flutter_cache
 - **Real web support** — persistent IndexedDB caching, not just browser HTTP cache.
 - **HTTP & cache interceptors** — inject auth headers, logging, or synthetic responses without forking anything.
 - **Pluggable eviction** — TTL (default) or LRU cleanup strategies.
+- **Pre-caching API** — `CachedNetworkImage.preCache()` downloads and caches images before they hit the screen, for instant navigation.
 - **Graceful unsupported-format handling** — SVG/AVIF/HEIC decode failures route to `unsupportedImageBuilder` instead of a bare exception.
 - **Actively maintained** — regular releases, community-driven roadmap.
 

--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.11.0] - 2026-09-01
+
+* **Feature:** Added `CachedNetworkImage.preCache()` static method for downloading and caching images without rendering them. Useful for warming the cache before navigation. Supports optional `cacheKey`, `headers`, custom `cacheManager`, and disk-resize parameters (`maxWidthDiskCache`, `maxHeightDiskCache`).
+
 ## [4.10.1] - 2026-08-26
 
 * **Fix:** `PathNotFoundException` when the background cleanup sweep deleted a cached file after `getFileFromCache` had already handed out its `FileInfo` but before the image was read. The sweep starts unawaited during initialization, so on cold start every first-frame load raced it. A cached file that disappears mid-read now falls back to a fresh download instead of throwing. Applies to the resize path too, which reads the separately-evictable original entry.

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -254,6 +254,37 @@ When `onStore` rejects, the downloaded file is copied to a system-temp location,
 cache-directory copy is deleted (no orphan), and the temp copy is yielded to the caller for
 this request only.
 
+### Pre-caching Images
+
+Download and cache images before they appear on screen, so navigation
+feels instant. `preCache` reuses the same cache manager and key logic as
+the widget.
+
+```dart
+// Warm the cache ahead of time (e.g. in initState or a splash screen).
+await CachedNetworkImage.preCache(
+  imageUrl: 'https://example.com/hero.jpg',
+);
+
+// Later, the widget loads from cache with no network wait.
+CachedNetworkImage(imageUrl: 'https://example.com/hero.jpg')
+```
+
+All parameters are optional except `imageUrl`:
+
+```dart
+await CachedNetworkImage.preCache(
+  imageUrl: 'https://example.com/hero.jpg',
+  cacheKey: 'hero',
+  headers: {'Authorization': 'Bearer token'},
+  cacheManager: myCustomCacheManager,
+  maxWidthDiskCache: 800,
+  maxHeightDiskCache: 600,
+);
+```
+
+Returns a `FileInfo` with the cached file path, expiry, and source.
+
 ### Unsupported Image Formats (SVG, JXL, AVIF, HEIC, ...)
 
 Flutter's built-in image codec can't decode every format. SVG never works

--- a/cached_network_image/example/analysis_options.yaml
+++ b/cached_network_image/example/analysis_options.yaml
@@ -1,1 +1,10 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: package:flutter_lints/flutter.yaml

--- a/cached_network_image/example/android/app/build.gradle.kts
+++ b/cached_network_image/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -15,8 +14,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 
     defaultConfig {

--- a/cached_network_image/example/android/gradle.properties
+++ b/cached_network_image/example/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/cached_network_image/example/android/settings.gradle.kts
+++ b/cached_network_image/example/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "9.3.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 include(":app")

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -309,7 +309,7 @@ class _PreCacheContentState extends State<PreCacheContent> {
     setState(() => _loading = true);
     try {
       await CachedNetworkImage.preCache(imageUrl: _imageUrl);
-      setState(() => _cached = true);
+      if (mounted) setState(() => _cached = true);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -34,16 +34,18 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 4,
+      length: 5,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('CachedNetworkImage CE'),
           bottom: const TabBar(
+            isScrollable: true,
             tabs: [
               Tab(icon: Icon(Icons.image), text: 'Basic'),
               Tab(icon: Icon(Icons.list), text: 'List'),
               Tab(icon: Icon(Icons.grid_on), text: 'Grid'),
               Tab(icon: Icon(Icons.speed), text: 'Benchmark'),
+              Tab(icon: Icon(Icons.download_done), text: 'PreCache'),
             ],
           ),
         ),
@@ -53,6 +55,7 @@ class HomePage extends StatelessWidget {
             ListContent(),
             GridContent(),
             BenchmarkContent(),
+            PreCacheContent(),
           ],
         ),
       ),
@@ -286,5 +289,69 @@ class GridContent extends StatelessWidget {
 
   Widget _error(BuildContext context, Object error, StackTrace? stackTrace) {
     return const Center(child: Icon(Icons.error));
+  }
+}
+
+class PreCacheContent extends StatefulWidget {
+  const PreCacheContent({super.key});
+
+  @override
+  State<PreCacheContent> createState() => _PreCacheContentState();
+}
+
+class _PreCacheContentState extends State<PreCacheContent> {
+  static const _imageUrl =
+      'https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=800';
+  bool _loading = false;
+  bool _cached = false;
+
+  Future<void> _preCache() async {
+    setState(() => _loading = true);
+    try {
+      await CachedNetworkImage.preCache(imageUrl: _imageUrl);
+      setState(() => _cached = true);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('PreCache failed: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (!_cached)
+            ElevatedButton.icon(
+              onPressed: _loading ? null : _preCache,
+              icon: _loading
+                  ? const SizedBox.square(
+                      dimension: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.download),
+              label: Text(_loading ? 'Pre-caching...' : 'Pre-cache image'),
+            ),
+          if (_cached) ...[
+            const Text('Image cached! Displaying from cache:'),
+            const SizedBox(height: 16),
+            SizedBox(
+              height: 300,
+              child: CachedNetworkImage(
+                imageUrl: _imageUrl,
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
   }
 }

--- a/cached_network_image/example/macos/Podfile
+++ b/cached_network_image/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/cached_network_image/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/cached_network_image/example/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		6965C321F1874F68973919E3 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF8ABB50A7D20538FA07409D /* Pods_Runner.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		FA8B9B63C59FBC8DC97AECA0 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD869FA37F91363EAFEBABD5 /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +63,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1C12274B8045C546864B39A4 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		2606CF433E431D1B396717BC /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +81,15 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		602164C5C35D85928136C66B /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		AD869FA37F91363EAFEBABD5 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0B11AAE60E46AB9E2F9C382 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		D1C1963E038EDED96DF0F48B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		EF8ABB50A7D20538FA07409D /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6C752FA8F5038537AB6B682 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA8B9B63C59FBC8DC97AECA0 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +105,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
+				6965C321F1874F68973919E3 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +140,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				DB450C9AD1A64034AF5BA146 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -151,6 +167,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -175,8 +192,24 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				EF8ABB50A7D20538FA07409D /* Pods_Runner.framework */,
+				AD869FA37F91363EAFEBABD5 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DB450C9AD1A64034AF5BA146 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				1C12274B8045C546864B39A4 /* Pods-Runner.debug.xcconfig */,
+				2606CF433E431D1B396717BC /* Pods-Runner.release.xcconfig */,
+				C0B11AAE60E46AB9E2F9C382 /* Pods-Runner.profile.xcconfig */,
+				602164C5C35D85928136C66B /* Pods-RunnerTests.debug.xcconfig */,
+				D1C1963E038EDED96DF0F48B /* Pods-RunnerTests.release.xcconfig */,
+				F6C752FA8F5038537AB6B682 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -186,6 +219,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				2E9524B10BCD067889653FE0 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,6 +238,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				52F18C435BDF115F52EDBC4E /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
@@ -216,6 +251,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* example.app */;
 			productType = "com.apple.product-type.application";
@@ -260,6 +298,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -291,6 +332,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2E9524B10BCD067889653FE0 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -328,6 +391,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		52F18C435BDF115F52EDBC4E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -380,6 +465,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 602164C5C35D85928136C66B /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +480,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = D1C1963E038EDED96DF0F48B /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +495,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F6C752FA8F5038537AB6B682 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -461,7 +549,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -543,7 +631,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -593,7 +681,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -700,6 +788,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/cached_network_image/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/cached_network_image/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "example.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -59,6 +77,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/cached_network_image/example/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/cached_network_image/example/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/cached_network_image/example/macos/Runner/AppDelegate.swift
+++ b/cached_network_image/example/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }
 }

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -79,8 +79,7 @@ class CachedNetworkImage extends StatefulWidget {
     int? maxWidthDiskCache,
     int? maxHeightDiskCache,
   }) async {
-    final cm =
-        cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
+    final cm = cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
 
     assert(
       cm is ImageCacheManager ||

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -65,6 +65,62 @@ class CachedNetworkImage extends StatefulWidget {
   static set logLevel(CacheManagerLogLevel level) =>
       CacheManager.logLevel = level;
 
+  /// Downloads and caches an image without rendering it.
+  ///
+  /// Use this to warm the cache before the image is needed on screen.
+  /// When [maxWidthDiskCache] or [maxHeightDiskCache] are provided and the
+  /// [cacheManager] supports [ImageCacheManager], the resized variant is
+  /// cached.
+  static Future<FileInfo> preCache({
+    required String imageUrl,
+    String? cacheKey,
+    Map<String, String>? headers,
+    BaseCacheManager? cacheManager,
+    int? maxWidthDiskCache,
+    int? maxHeightDiskCache,
+  }) async {
+    final cm =
+        cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
+
+    assert(
+      cm is ImageCacheManager ||
+          (maxWidthDiskCache == null && maxHeightDiskCache == null),
+      'To resize the image the CacheManager needs to be an '
+      'ImageCacheManager. maxWidthDiskCache and maxHeightDiskCache will '
+      'be ignored when a normal CacheManager is used.',
+    );
+
+    final Stream<FileResponse> stream;
+    if (cm is ImageCacheManager &&
+        (maxWidthDiskCache != null || maxHeightDiskCache != null)) {
+      stream = cm.getImageFile(
+        imageUrl,
+        key: cacheKey,
+        headers: headers,
+        maxWidth: maxWidthDiskCache,
+        maxHeight: maxHeightDiskCache,
+      );
+    } else {
+      stream = cm.getFileStream(
+        imageUrl,
+        key: cacheKey,
+        headers: headers,
+      );
+    }
+
+    // Drain the entire stream and return the last FileInfo. This ensures
+    // that when the cache manager yields a stale entry followed by a
+    // refreshed one, we wait for the refresh to complete.
+    FileInfo? result;
+    await for (final response in stream) {
+      if (response is FileInfo) result = response;
+    }
+    if (result == null) {
+      throw StateError('Cache manager completed without providing a file');
+    }
+    return result;
+  }
+
   /// Evict an image from both the disk file based caching system of the
   /// [BaseCacheManager] as the in memory [ImageCache] of the [ImageProvider].
   /// [url] is used by both the disk and memory cache. The scale is only used

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.10.1
+version: 4.11.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/precache_test.dart
+++ b/cached_network_image/test/precache_test.dart
@@ -1,0 +1,155 @@
+import 'dart:async';
+
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'fake_cache_manager.dart';
+import 'image_data.dart';
+
+void main() {
+  const url = 'https://example.com/image.png';
+
+  group('CachedNetworkImage.preCache', () {
+    test('downloads and returns FileInfo via getFileStream', () async {
+      final cacheManager = FakeCacheManager();
+      cacheManager.returns(url, kTransparentImage);
+
+      final result = await CachedNetworkImage.preCache(
+        imageUrl: url,
+        cacheManager: cacheManager,
+      );
+
+      expect(result, isA<FileInfo>());
+      expect(result.originalUrl, url);
+      verify(
+        () => cacheManager.getFileStream(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+        ),
+      ).called(1);
+    });
+
+    test('passes cacheKey as key to getFileStream', () async {
+      const cacheKey = 'custom-key';
+      final cacheManager = FakeCacheManager();
+      cacheManager.returns(url, kTransparentImage);
+
+      await CachedNetworkImage.preCache(
+        imageUrl: url,
+        cacheKey: cacheKey,
+        cacheManager: cacheManager,
+      );
+
+      verify(
+        () => cacheManager.getFileStream(
+          url,
+          key: cacheKey,
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+        ),
+      ).called(1);
+    });
+
+    test('passes headers to getFileStream', () async {
+      final headers = {'Authorization': 'Bearer token'};
+      final cacheManager = FakeCacheManager();
+      cacheManager.returns(url, kTransparentImage);
+
+      await CachedNetworkImage.preCache(
+        imageUrl: url,
+        headers: headers,
+        cacheManager: cacheManager,
+      );
+
+      verify(
+        () => cacheManager.getFileStream(
+          url,
+          key: any(named: 'key'),
+          headers: headers,
+          withProgress: any(named: 'withProgress'),
+        ),
+      ).called(1);
+    });
+
+    test('uses getImageFile when resize params provided', () async {
+      final cacheManager = FakeImageCacheManager();
+      cacheManager.returns(url, kTransparentImage);
+
+      final result = await CachedNetworkImage.preCache(
+        imageUrl: url,
+        cacheManager: cacheManager,
+        maxWidthDiskCache: 200,
+        maxHeightDiskCache: 100,
+      );
+
+      expect(result, isA<FileInfo>());
+      verify(
+        () => cacheManager.getImageFile(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+          maxWidth: 200,
+          maxHeight: 100,
+        ),
+      ).called(1);
+    });
+
+    test('drains stream fully so stale cache is refreshed', () async {
+      final staleFile =
+          MemoryFileSystem().systemTempDirectory.childFile('stale.jpg');
+      staleFile.writeAsBytesSync(kTransparentImage);
+      final freshFile =
+          MemoryFileSystem().systemTempDirectory.childFile('fresh.jpg');
+      freshFile.writeAsBytesSync(kTransparentImage);
+
+      final staleInfo = FileInfo(
+        staleFile,
+        FileSource.Cache,
+        DateTime.now().subtract(const Duration(hours: 1)),
+        url,
+      );
+      final freshInfo = FileInfo(
+        freshFile,
+        FileSource.Online,
+        DateTime.now().add(const Duration(days: 7)),
+        url,
+      );
+
+      final cacheManager = FakeCacheManager();
+      when(
+        () => cacheManager.getFileStream(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+        ),
+      ).thenAnswer((_) => Stream.fromIterable([staleInfo, freshInfo]));
+
+      final result = await CachedNetworkImage.preCache(
+        imageUrl: url,
+        cacheManager: cacheManager,
+      );
+
+      expect(result.source, FileSource.Online);
+      expect(result.validTill.isAfter(DateTime.now()), isTrue);
+    });
+
+    test('propagates errors from cache manager', () async {
+      final cacheManager = FakeCacheManager();
+      cacheManager.throwsNotFound(url);
+
+      expect(
+        () => CachedNetworkImage.preCache(
+          imageUrl: url,
+          cacheManager: cacheManager,
+        ),
+        throwsA(isA<HttpExceptionWithStatus>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Introduce a `preCache` static method to `CachedNetworkImage` for warming the cache by downloading and caching an image without rendering it. This allows `CachedNetworkImage` widgets to load images from cache instantly. A new `PreCache` tab is added to the example app to demonstrate this feature.

## Related Issues

Fixes #63

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `preCache` API to download and cache images before they are displayed.
  * Added support for custom cache keys, request headers, cache managers, and disk resizing options.
  * Added an example screen demonstrating pre-caching progress, error notifications, and cached image display.

* **Documentation**
  * Documented the pre-caching API, options, and returned cache information.

* **Tests**
  * Added coverage for successful pre-caching, resizing, refreshed downloads, custom options, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->