### PR TITLE
feat: static defaults for image builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Shipping something with it? [Open a PR](https://github.com/Erengun/flutter_cache
 - **Real web support** — persistent IndexedDB caching, not just browser HTTP cache.
 - **HTTP & cache interceptors** — inject auth headers, logging, or synthetic responses without forking anything.
 - **Pluggable eviction** — TTL (default) or LRU cleanup strategies.
+- **Global default builders** — set the placeholder, error and progress builders once for the whole app.
 - **Graceful unsupported-format handling** — SVG/AVIF/HEIC decode failures route to `unsupportedImageBuilder` instead of a bare exception.
 - **Actively maintained** — regular releases, community-driven roadmap.
 
@@ -164,7 +165,7 @@ CachedNetworkImage(
 
 ## Full docs and advanced usage
 
-The quick start above covers the basics. For interceptors, cleanup strategies, connection timeouts, custom cache and metadata directories, web render modes, and unsupported-format handling, see the full reference:
+The quick start above covers the basics. For interceptors, cleanup strategies, connection timeouts, custom cache and metadata directories, web render modes, global default builders, and unsupported-format handling, see the full reference:
 
 [`cached_network_image/README.md`](cached_network_image/README.md)
 

--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## (unreleased)
+
+* **Feature:** Added app-wide static defaults on `CachedNetworkImage`, so the builders can be set once instead of at every call site: `defaultImageBuilder`, `defaultPlaceholder`, `defaultProgressIndicatorBuilder`, `defaultErrorBuilder`, `defaultUnsupportedImageBuilder`, `defaultPlaceholderFadeInDuration` and `defaultErrorListener`. A value passed to the widget always wins over the static one; resolution is exposed through the new `effectiveX` getters.
+
 ## [4.10.1] - 2026-08-26
 
 * **Fix:** `PathNotFoundException` when the background cleanup sweep deleted a cached file after `getFileFromCache` had already handed out its `FileInfo` but before the image was read. The sweep starts unawaited during initialization, so on cold start every first-frame load raced it. A cached file that disappears mid-read now falls back to a fresh download instead of throwing. Applies to the resize path too, which reads the separately-evictable original entry.

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -111,6 +111,47 @@ CachedNetworkImage(
 ),
 ```
 
+### Global Default Builders
+
+Set the builders once instead of repeating them at every call site. The statics
+are used by every `CachedNetworkImage` that does not pass its own value:
+
+```dart
+void main() {
+  CachedNetworkImage.defaultPlaceholder = (context, url) => const Center(
+        child: CircularProgressIndicator(),
+      );
+  CachedNetworkImage.defaultErrorBuilder = (context, error, stackTrace) =>
+      const Icon(Icons.broken_image);
+
+  CachedNetworkImage.defaultPlaceholderFadeInDuration =
+      const Duration(milliseconds: 300);
+
+  runApp(const MyApp());
+}
+
+// Uses the globals above.
+CachedNetworkImage(imageUrl: url);
+
+// A value passed to the widget always wins over the global one.
+CachedNetworkImage(
+  imageUrl: url,
+  errorBuilder: (context, error, stackTrace) => const Text('failed'),
+);
+```
+
+Available statics:
+
+| Static | Overrides |
+| --- | --- |
+| `CachedNetworkImage.defaultImageBuilder` | `imageBuilder` |
+| `CachedNetworkImage.defaultPlaceholder` | `placeholder` |
+| `CachedNetworkImage.defaultProgressIndicatorBuilder` | `progressIndicatorBuilder` |
+| `CachedNetworkImage.defaultErrorBuilder` | `errorBuilder` |
+| `CachedNetworkImage.defaultUnsupportedImageBuilder` | `unsupportedImageBuilder` |
+| `CachedNetworkImage.defaultPlaceholderFadeInDuration` | `placeholderFadeInDuration` |
+| `CachedNetworkImage.defaultErrorListener` | `errorListener` |
+
 ### Direct ImageProvider Usage
 
 ```dart

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -65,6 +65,48 @@ class CachedNetworkImage extends StatefulWidget {
   static set logLevel(CacheManagerLogLevel level) =>
       CacheManager.logLevel = level;
 
+  /// App-wide fallback for [imageBuilder].
+  ///
+  /// Used by every [CachedNetworkImage] that does not pass its own
+  /// [imageBuilder].
+  static ImageWidgetBuilder? defaultImageBuilder;
+
+  /// App-wide fallback for [placeholder].
+  ///
+  /// Used by every [CachedNetworkImage] that does not pass its own
+  /// [placeholder].
+  static PlaceholderWidgetBuilder? defaultPlaceholder;
+
+  /// App-wide fallback for [progressIndicatorBuilder].
+  ///
+  /// Used by every [CachedNetworkImage] that does not pass its own
+  /// [progressIndicatorBuilder].
+  static ProgressIndicatorBuilder? defaultProgressIndicatorBuilder;
+
+  /// App-wide fallback for [errorBuilder].
+  ///
+  /// Used by every [CachedNetworkImage] that does not pass its own
+  /// [errorBuilder].
+  static ImageErrorWidgetBuilder? defaultErrorBuilder;
+
+  /// App-wide fallback for [unsupportedImageBuilder].
+  ///
+  /// Used by every [CachedNetworkImage] that does not pass its own
+  /// [unsupportedImageBuilder].
+  static UnsupportedImageWidgetBuilder? defaultUnsupportedImageBuilder;
+
+  /// App-wide fallback for [placeholderFadeInDuration].
+  ///
+  /// Used by every [CachedNetworkImage] that does not pass its own
+  /// [placeholderFadeInDuration].
+  static Duration? defaultPlaceholderFadeInDuration;
+
+  /// App-wide fallback for [errorListener].
+  ///
+  /// Used by every [CachedNetworkImage] that does not pass its own
+  /// [errorListener].
+  static ValueChanged<Object>? defaultErrorListener;
+
   /// Evict an image from both the disk file based caching system of the
   /// [BaseCacheManager] as the in memory [ImageCache] of the [ImageProvider].
   /// [url] is used by both the disk and memory cache. The scale is only used
@@ -319,6 +361,37 @@ class CachedNetworkImage extends StatefulWidget {
     this.disablePlaceholderOnCacheHit = true,
   });
 
+  /// [imageBuilder] of this widget, or [defaultImageBuilder] if not given.
+  ImageWidgetBuilder? get effectiveImageBuilder =>
+      imageBuilder ?? defaultImageBuilder;
+
+  /// [placeholder] of this widget, or [defaultPlaceholder] if not given.
+  PlaceholderWidgetBuilder? get effectivePlaceholder =>
+      placeholder ?? defaultPlaceholder;
+
+  /// [progressIndicatorBuilder] of this widget, or
+  /// [defaultProgressIndicatorBuilder] if not given.
+  ProgressIndicatorBuilder? get effectiveProgressIndicatorBuilder =>
+      progressIndicatorBuilder ?? defaultProgressIndicatorBuilder;
+
+  /// [errorBuilder] of this widget, or [defaultErrorBuilder] if not given.
+  ImageErrorWidgetBuilder? get effectiveErrorBuilder =>
+      errorBuilder ?? defaultErrorBuilder;
+
+  /// [unsupportedImageBuilder] of this widget, or
+  /// [defaultUnsupportedImageBuilder] if not given.
+  UnsupportedImageWidgetBuilder? get effectiveUnsupportedImageBuilder =>
+      unsupportedImageBuilder ?? defaultUnsupportedImageBuilder;
+
+  /// [placeholderFadeInDuration] of this widget, or
+  /// [defaultPlaceholderFadeInDuration] if not given.
+  Duration? get effectivePlaceholderFadeInDuration =>
+      placeholderFadeInDuration ?? defaultPlaceholderFadeInDuration;
+
+  /// [errorListener] of this widget, or [defaultErrorListener] if not given.
+  ValueChanged<Object>? get effectiveErrorListener =>
+      errorListener ?? defaultErrorListener;
+
   @override
   State<CachedNetworkImage> createState() => _CachedNetworkImageState();
 }
@@ -388,7 +461,7 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
       imageRenderMethodForWeb: widget.imageRenderMethodForWeb,
       maxWidth: widget.maxWidthDiskCache,
       maxHeight: widget.maxHeightDiskCache,
-      errorListener: widget.errorListener,
+      errorListener: widget.effectiveErrorListener,
       scale: widget.scale,
       minimumGifFrameDuration: widget.minimumGifFrameDuration,
     );
@@ -416,19 +489,19 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
 
   @override
   Widget build(BuildContext context) {
-    final hasCustomBuilder = widget.imageBuilder != null ||
-        widget.placeholder != null ||
-        widget.progressIndicatorBuilder != null ||
+    final hasCustomBuilder = widget.effectiveImageBuilder != null ||
+        widget.effectivePlaceholder != null ||
+        widget.effectiveProgressIndicatorBuilder != null ||
         widget.errorWidget != null ||
-        widget.errorBuilder != null ||
-        widget.unsupportedImageBuilder != null;
+        widget.effectiveErrorBuilder != null ||
+        widget.effectiveUnsupportedImageBuilder != null;
 
     OctoPlaceholderBuilder? octoPlaceholderBuilder;
     OctoProgressIndicatorBuilder? octoProgressIndicatorBuilder;
     Duration? effectiveFadeOutDuration = widget.fadeOutDuration;
     Duration effectiveFadeInDuration = widget.fadeInDuration;
     Duration? effectivePlaceholderFadeInDuration =
-        widget.placeholderFadeInDuration;
+        widget.effectivePlaceholderFadeInDuration;
 
     if (_skipPlaceholder) {
       // Image is in disk cache — skip placeholder and fade animations
@@ -440,10 +513,11 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
       effectivePlaceholderFadeInDuration = Duration.zero;
     } else {
       octoPlaceholderBuilder =
-          widget.placeholder != null ? _octoPlaceholderBuilder : null;
-      octoProgressIndicatorBuilder = widget.progressIndicatorBuilder != null
-          ? _octoProgressIndicatorBuilder
-          : null;
+          widget.effectivePlaceholder != null ? _octoPlaceholderBuilder : null;
+      octoProgressIndicatorBuilder =
+          widget.effectiveProgressIndicatorBuilder != null
+              ? _octoProgressIndicatorBuilder
+              : null;
 
       /// If there is no placeholder OctoImage does not fade, so always set an
       /// (empty) placeholder as this always used to be the behaviour of
@@ -456,7 +530,8 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
 
     return OctoImage(
       image: _image,
-      imageBuilder: widget.imageBuilder != null ? _octoImageBuilder : null,
+      imageBuilder:
+          widget.effectiveImageBuilder != null ? _octoImageBuilder : null,
       placeholderBuilder: octoPlaceholderBuilder,
       progressIndicatorBuilder: octoProgressIndicatorBuilder,
       errorBuilder: hasCustomBuilder ? _octoErrorBuilder : null,
@@ -481,11 +556,11 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
   }
 
   Widget _octoImageBuilder(BuildContext context, Widget child) {
-    return widget.imageBuilder!(context, _image);
+    return widget.effectiveImageBuilder!(context, _image);
   }
 
   Widget _octoPlaceholderBuilder(BuildContext context) {
-    return widget.placeholder!(context, widget.imageUrl);
+    return widget.effectivePlaceholder!(context, widget.imageUrl);
   }
 
   Widget _octoProgressIndicatorBuilder(
@@ -498,7 +573,7 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
       totalSize = progress.expectedTotalBytes;
       downloaded = progress.cumulativeBytesLoaded;
     }
-    return widget.progressIndicatorBuilder!(
+    return widget.effectiveProgressIndicatorBuilder!(
       context,
       widget.imageUrl,
       DownloadProgress(widget.imageUrl, totalSize, downloaded),
@@ -511,12 +586,12 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
     StackTrace? stackTrace,
   ) {
     if (error is UnsupportedImageFormatException &&
-        widget.unsupportedImageBuilder != null) {
-      return widget.unsupportedImageBuilder!(
+        widget.effectiveUnsupportedImageBuilder != null) {
+      return widget.effectiveUnsupportedImageBuilder!(
           context, widget.imageUrl, error.bytes);
     }
-    if (widget.errorBuilder != null) {
-      return widget.errorBuilder!(context, error, stackTrace);
+    if (widget.effectiveErrorBuilder != null) {
+      return widget.effectiveErrorBuilder!(context, error, stackTrace);
     }
     if (widget.errorWidget != null) {
       return widget.errorWidget!(context, widget.imageUrl, error);

--- a/cached_network_image/test/cached_image_widget_static_defaults_test.dart
+++ b/cached_network_image/test/cached_image_widget_static_defaults_test.dart
@@ -1,0 +1,181 @@
+import 'dart:typed_data';
+
+import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_cache_manager.dart';
+import 'image_data.dart';
+
+void main() {
+  late FakeCacheManager cacheManager;
+
+  setUp(() {
+    cacheManager = FakeCacheManager();
+  });
+
+  tearDown(() {
+    CachedNetworkImage.defaultImageBuilder = null;
+    CachedNetworkImage.defaultPlaceholder = null;
+    CachedNetworkImage.defaultProgressIndicatorBuilder = null;
+    CachedNetworkImage.defaultErrorBuilder = null;
+    CachedNetworkImage.defaultUnsupportedImageBuilder = null;
+    CachedNetworkImage.defaultPlaceholderFadeInDuration = null;
+    CachedNetworkImage.defaultErrorListener = null;
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
+  });
+
+  group('CachedNetworkImage static defaults', () {
+    testWidgets('defaultErrorBuilder is used when errorBuilder is not given',
+        (tester) async {
+      var imageUrl = 'static-error-builder-test';
+      cacheManager.throwsNotFound(imageUrl);
+      var called = false;
+      CachedNetworkImage.defaultErrorBuilder = (context, error, stackTrace) {
+        called = true;
+        return const Icon(Icons.error);
+      };
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              disablePlaceholderOnCacheHit: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(called, isTrue);
+    });
+
+    testWidgets('errorBuilder of the widget wins over defaultErrorBuilder',
+        (tester) async {
+      var imageUrl = 'static-error-builder-override-test';
+      cacheManager.throwsNotFound(imageUrl);
+      var staticCalled = false;
+      var localCalled = false;
+      CachedNetworkImage.defaultErrorBuilder = (context, error, stackTrace) {
+        staticCalled = true;
+        return const Icon(Icons.error);
+      };
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              disablePlaceholderOnCacheHit: false,
+              errorBuilder: (context, error, stackTrace) {
+                localCalled = true;
+                return const Icon(Icons.broken_image);
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(localCalled, isTrue);
+      expect(staticCalled, isFalse);
+    });
+
+    testWidgets('defaultPlaceholder is used when placeholder is not given',
+        (tester) async {
+      var imageUrl = 'static-placeholder-test';
+      cacheManager.returns(imageUrl, kTransparentImage);
+      var called = false;
+      CachedNetworkImage.defaultPlaceholder = (context, url) {
+        called = true;
+        return const CircularProgressIndicator();
+      };
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              disablePlaceholderOnCacheHit: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(called, isTrue);
+    });
+
+    testWidgets(
+        'defaultProgressIndicatorBuilder is used when builder is not given',
+        (tester) async {
+      var imageUrl = 'static-progress-test';
+      cacheManager.returns(imageUrl, kTransparentImage);
+      DownloadProgress? lastProgress;
+      CachedNetworkImage.defaultProgressIndicatorBuilder =
+          (context, url, progress) {
+        lastProgress = progress;
+        return const CircularProgressIndicator();
+      };
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              disablePlaceholderOnCacheHit: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(lastProgress, isNotNull);
+      expect(lastProgress!.originalUrl, imageUrl);
+    });
+
+    test('effective getters fall back to the static defaults', () {
+      const widget = CachedNetworkImage(imageUrl: 'effective-getters-test');
+      expect(widget.effectiveImageBuilder, isNull);
+      expect(widget.effectiveUnsupportedImageBuilder, isNull);
+      expect(widget.effectiveErrorListener, isNull);
+      expect(widget.effectivePlaceholderFadeInDuration, isNull);
+
+      Widget imageBuilder(BuildContext context, ImageProvider provider) =>
+          const SizedBox.shrink();
+      Widget unsupportedImageBuilder(
+        BuildContext context,
+        String url,
+        Uint8List bytes,
+      ) =>
+          const SizedBox.shrink();
+      void errorListener(Object error) {}
+
+      CachedNetworkImage.defaultImageBuilder = imageBuilder;
+      CachedNetworkImage.defaultUnsupportedImageBuilder =
+          unsupportedImageBuilder;
+      CachedNetworkImage.defaultErrorListener = errorListener;
+      expect(widget.effectiveImageBuilder, imageBuilder);
+      expect(widget.effectiveUnsupportedImageBuilder, unsupportedImageBuilder);
+      expect(widget.effectiveErrorListener, errorListener);
+
+      CachedNetworkImage.defaultPlaceholderFadeInDuration =
+          const Duration(milliseconds: 300);
+      expect(
+        widget.effectivePlaceholderFadeInDuration,
+        const Duration(milliseconds: 300),
+      );
+
+      const widgetWithOwnValue = CachedNetworkImage(
+        imageUrl: 'effective-getters-test',
+        placeholderFadeInDuration: Duration(milliseconds: 50),
+      );
+      expect(
+        widgetWithOwnValue.effectivePlaceholderFadeInDuration,
+        const Duration(milliseconds: 50),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

This PR adds an ability to change default image builders (error, loading, ...) globally:
```dart
// In main method (before runApp):
CachedNetworkImage.defaultPlaceholder = (context, url) => const Center(
  child: CircularProgressIndicator(),
);

CachedNetworkImage.defaultErrorBuilder = (context, error, stackTrace) =>
  const Icon(Icons.broken_image);

CachedNetworkImage.defaultPlaceholderFadeInDuration = const Duration(milliseconds: 300);
```

List of all available static fields that can be changed:
- `defaultImageBuilder`
- `defaultPlaceholder`
- `defaultProgressIndicatorBuilder`
- `defaultErrorBuilder`
- `defaultUnsupportedImageBuilder`
- `defaultPlaceholderFadeInDuration`
- `defaultErrorListener`

## Related Issues

*None, this is a new feature.*

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app-wide default builders and settings for cached images, placeholders, progress indicators, errors, unsupported formats, fade-in duration, and error handling.
  * Widget-level configuration continues to override app-wide defaults.
  * Added effective settings that reflect the final configuration used by each widget.

* **Documentation**
  * Added usage guidance and examples for configuring global defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->