### PR TITLE
Add preCache static method with enhanced error handling and timeout support

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [4.11.0] - 2026-09-01
 
-* **Feature:** Added `CachedNetworkImage.preCache()` static method for downloading and caching images without rendering them. Useful for warming the cache before navigation. Supports optional `cacheKey`, `headers`, custom `cacheManager`, and disk-resize parameters (`maxWidthDiskCache`, `maxHeightDiskCache`).
+* **Feature:** Added `CachedNetworkImage.preCache()` static method for downloading and caching images without rendering them. Useful for warming the cache before navigation. Supports optional `cacheKey`, `headers`, custom `cacheManager`, disk-resize parameters (`maxWidthDiskCache`, `maxHeightDiskCache`), and an optional `timeout`. Throws a `StateError` instead of silently returning a stale file when refreshing an expired cache entry fails, and an `ArgumentError` (not just an `assert`) when resize parameters are used with a `CacheManager` that isn't an `ImageCacheManager`.
 
 ## [4.10.1] - 2026-08-26
 

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -280,10 +280,17 @@ await CachedNetworkImage.preCache(
   cacheManager: myCustomCacheManager,
   maxWidthDiskCache: 800,
   maxHeightDiskCache: 600,
+  timeout: const Duration(seconds: 10),
 );
 ```
 
-Returns a `FileInfo` with the cached file path, expiry, and source.
+Returns a `FileInfo` with the cached file path, expiry, and source. Waits
+for an expired cache entry to finish refreshing before returning, and
+throws a `StateError` instead of returning a stale file if that refresh
+fails. `timeout`, if given, throws a `TimeoutException` when exceeded but
+does not cancel the underlying download. `maxWidthDiskCache` /
+`maxHeightDiskCache` throw an `ArgumentError` when `cacheManager` isn't an
+`ImageCacheManager`.
 
 ### Unsupported Image Formats (SVG, JXL, AVIF, HEIC, ...)
 

--- a/cached_network_image/example/android/gradle.properties
+++ b/cached_network_image/example/android/gradle.properties
@@ -1,6 +1,4 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-# This builtInKotlin flag was added automatically by Flutter migrator
-android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -72,6 +72,16 @@ class CachedNetworkImage extends StatefulWidget {
   /// When [maxWidthDiskCache] or [maxHeightDiskCache] are provided and the
   /// [cacheManager] supports [ImageCacheManager], the resized variant is
   /// cached.
+  ///
+  /// Waits for the cache manager to finish refreshing an expired cache
+  /// entry before returning. If the refresh fails and only the stale
+  /// cached file remains, this throws a [StateError] rather than
+  /// returning that stale file as if it were success.
+  ///
+  /// [timeout], if given, is applied between events on the underlying
+  /// stream via [Stream.timeout] and throws a [TimeoutException] when
+  /// exceeded. It unblocks the caller but does not cancel the in-flight
+  /// download.
   static Future<FileInfo> preCache({
     required String imageUrl,
     String? cacheKey,
@@ -79,18 +89,20 @@ class CachedNetworkImage extends StatefulWidget {
     BaseCacheManager? cacheManager,
     int? maxWidthDiskCache,
     int? maxHeightDiskCache,
+    Duration? timeout,
   }) async {
-    final cm = cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
+    final cm = _effectiveCacheManager(cacheManager);
 
-    assert(
-      cm is ImageCacheManager ||
-          (maxWidthDiskCache == null && maxHeightDiskCache == null),
-      'To resize the image the CacheManager needs to be an '
-      'ImageCacheManager. maxWidthDiskCache and maxHeightDiskCache will '
-      'be ignored when a normal CacheManager is used.',
-    );
+    if (cm is! ImageCacheManager &&
+        (maxWidthDiskCache != null || maxHeightDiskCache != null)) {
+      throw ArgumentError(
+        'To resize the image the CacheManager needs to be an '
+        'ImageCacheManager. maxWidthDiskCache and maxHeightDiskCache will '
+        'be ignored when a normal CacheManager is used.',
+      );
+    }
 
-    final Stream<FileResponse> stream;
+    Stream<FileResponse> stream;
     if (cm is ImageCacheManager &&
         (maxWidthDiskCache != null || maxHeightDiskCache != null)) {
       stream = cm.getImageFile(
@@ -107,6 +119,9 @@ class CachedNetworkImage extends StatefulWidget {
         headers: headers,
       );
     }
+    if (timeout != null) {
+      stream = stream.timeout(timeout);
+    }
 
     // Drain the entire stream and return the last FileInfo. This ensures
     // that when the cache manager yields a stale entry followed by a
@@ -117,6 +132,16 @@ class CachedNetworkImage extends StatefulWidget {
     }
     if (result == null) {
       throw StateError('Cache manager completed without providing a file');
+    }
+    // A successful refresh always yields a FileInfo sourced from the
+    // network (see DefaultCacheManager._downloadFile), so a Cache-sourced
+    // result that is still expired means the refresh silently failed.
+    if (result.source == FileSource.Cache &&
+        result.validTill.isBefore(DateTime.now())) {
+      throw StateError(
+        'preCache failed to refresh $imageUrl: the cache manager only '
+        'returned a stale cached file.',
+      );
     }
     return result;
   }
@@ -132,8 +157,7 @@ class CachedNetworkImage extends StatefulWidget {
     double scale = 1,
     Duration minimumGifFrameDuration = const Duration(milliseconds: 100),
   }) async {
-    final effectiveCacheManager =
-        cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
+    final effectiveCacheManager = _effectiveCacheManager(cacheManager);
     await effectiveCacheManager.removeFile(cacheKey ?? url);
     return CachedNetworkImageProvider(
       url,
@@ -141,6 +165,11 @@ class CachedNetworkImage extends StatefulWidget {
       minimumGifFrameDuration: minimumGifFrameDuration,
     ).evict();
   }
+
+  static BaseCacheManager _effectiveCacheManager(
+    BaseCacheManager? cacheManager,
+  ) =>
+      cacheManager ?? CachedNetworkImageProvider.defaultCacheManager;
 
   /// Option to use cacheManager with other settings
   final BaseCacheManager? cacheManager;

--- a/cached_network_image/lib/src/image_provider/_image_loader.dart
+++ b/cached_network_image/lib/src/image_provider/_image_loader.dart
@@ -89,9 +89,9 @@ class ImageLoader implements platform.ImageLoader {
       assert(
           cacheManager is ImageCacheManager ||
               (maxWidth == null && maxHeight == null),
-          'To resize the image with a CacheManager the '
-          'CacheManager needs to be an ImageCacheManager. maxWidth and '
-          'maxHeight will be ignored when a normal CacheManager is used.');
+          'To resize the image the CacheManager needs to be an '
+          'ImageCacheManager. maxWidth and maxHeight will be ignored when '
+          'a normal CacheManager is used.');
 
       // A cache manager can delete a cached file during its own eviction
       // sweep after it has already handed out the FileInfo pointing at it,

--- a/cached_network_image/test/precache_test.dart
+++ b/cached_network_image/test/precache_test.dart
@@ -12,12 +12,17 @@ void main() {
   const url = 'https://example.com/image.png';
 
   group('CachedNetworkImage.preCache', () {
-    test('downloads and returns FileInfo via getFileStream', () async {
+    test('downloads and returns FileInfo, passing cacheKey and headers '
+        'through to getFileStream', () async {
+      const cacheKey = 'custom-key';
+      final headers = {'Authorization': 'Bearer token'};
       final cacheManager = FakeCacheManager();
       cacheManager.returns(url, kTransparentImage);
 
       final result = await CachedNetworkImage.preCache(
         imageUrl: url,
+        cacheKey: cacheKey,
+        headers: headers,
         cacheManager: cacheManager,
       );
 
@@ -26,49 +31,7 @@ void main() {
       verify(
         () => cacheManager.getFileStream(
           url,
-          key: any(named: 'key'),
-          headers: any(named: 'headers'),
-          withProgress: any(named: 'withProgress'),
-        ),
-      ).called(1);
-    });
-
-    test('passes cacheKey as key to getFileStream', () async {
-      const cacheKey = 'custom-key';
-      final cacheManager = FakeCacheManager();
-      cacheManager.returns(url, kTransparentImage);
-
-      await CachedNetworkImage.preCache(
-        imageUrl: url,
-        cacheKey: cacheKey,
-        cacheManager: cacheManager,
-      );
-
-      verify(
-        () => cacheManager.getFileStream(
-          url,
           key: cacheKey,
-          headers: any(named: 'headers'),
-          withProgress: any(named: 'withProgress'),
-        ),
-      ).called(1);
-    });
-
-    test('passes headers to getFileStream', () async {
-      final headers = {'Authorization': 'Bearer token'};
-      final cacheManager = FakeCacheManager();
-      cacheManager.returns(url, kTransparentImage);
-
-      await CachedNetworkImage.preCache(
-        imageUrl: url,
-        headers: headers,
-        cacheManager: cacheManager,
-      );
-
-      verify(
-        () => cacheManager.getFileStream(
-          url,
-          key: any(named: 'key'),
           headers: headers,
           withProgress: any(named: 'withProgress'),
         ),
@@ -151,5 +114,73 @@ void main() {
         throwsA(isA<HttpExceptionWithStatus>()),
       );
     });
+
+    test('throws when only a stale cached file is returned', () async {
+      final staleFile =
+          MemoryFileSystem().systemTempDirectory.childFile('stale.jpg');
+      staleFile.writeAsBytesSync(kTransparentImage);
+      final staleInfo = FileInfo(
+        staleFile,
+        FileSource.Cache,
+        DateTime.now().subtract(const Duration(hours: 1)),
+        url,
+      );
+
+      final cacheManager = FakeCacheManager();
+      when(
+        () => cacheManager.getFileStream(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+        ),
+      ).thenAnswer((_) => Stream.value(staleInfo));
+
+      expect(
+        () => CachedNetworkImage.preCache(
+          imageUrl: url,
+          cacheManager: cacheManager,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('throws TimeoutException when timeout elapses', () async {
+      final cacheManager = FakeCacheManager();
+      when(
+        () => cacheManager.getFileStream(
+          url,
+          key: any(named: 'key'),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+        ),
+      ).thenAnswer((_) => StreamController<FileResponse>().stream);
+
+      expect(
+        () => CachedNetworkImage.preCache(
+          imageUrl: url,
+          cacheManager: cacheManager,
+          timeout: const Duration(milliseconds: 10),
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test(
+      'throws ArgumentError when resize params are used with a plain '
+      'CacheManager',
+      () async {
+        final cacheManager = FakeCacheManager();
+
+        expect(
+          () => CachedNetworkImage.preCache(
+            imageUrl: url,
+            cacheManager: cacheManager,
+            maxWidthDiskCache: 200,
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
   });
 }

--- a/cached_network_image/test/precache_test.dart
+++ b/cached_network_image/test/precache_test.dart
@@ -12,7 +12,8 @@ void main() {
   const url = 'https://example.com/image.png';
 
   group('CachedNetworkImage.preCache', () {
-    test('downloads and returns FileInfo, passing cacheKey and headers '
+    test(
+        'downloads and returns FileInfo, passing cacheKey and headers '
         'through to getFileStream', () async {
       const cacheKey = 'custom-key';
       final headers = {'Authorization': 'Bearer token'};


### PR DESCRIPTION
## Description

Introduce a `preCache` static method for downloading and caching images without rendering. This method enhances error handling by throwing exceptions for stale files and invalid parameters, and it supports a timeout feature.

## Related Issues

*No related issues.*

## Checklist

- [ ] I've read the [Contributor Guide]
- [ ] All existing tests pass
- [ ] I've added new tests for any new features or bug fixes
- [ ] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional timeout when pre-caching images.
  - Pre-caching now reports failures when refreshing expired cache entries.
  - Invalid resize settings are reported with clear argument errors.

- **Bug Fixes**
  - Improved handling of stale cached images when a refresh fails.
  - Added consistent cache-manager behavior for pre-caching and cache eviction.

- **Documentation**
  - Expanded guidance on pre-cache timeouts, refresh failures, and supported resize configurations.
  - Updated the pre-caching example to demonstrate the timeout option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->