### PR TITLE
Add animation control for multi-frame images in CachedNetworkImage

### DIFF
--- a/cached_network_image/CHANGELOG.md
+++ b/cached_network_image/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.12.0] - 2026-09-08
+
+* **Feature:** Added `animate` to `CachedNetworkImage` and `CachedNetworkImageProvider` (default `true`). With `animate: false` a multi-frame image such as a GIF shows its first frame and stops there, without decoding the rest. `animate` is part of the provider key, so toggling it at runtime resolves a different image stream: the widget paints nothing while that stream resolves, and which frame it starts on depends on what the `ImageCache` still holds. Wrap the widget in a `TickerMode` to pause and resume an animation in place. Requested in issue #21.
+* **Fix:** `CachedNetworkImage.evictFromCache` now forwards `cacheKey` to the provider it evicts and clears both the `animate: true` and `animate: false` entries, so the in-memory `ImageCache` eviction is no longer a silent no-op for images rendered with a `cacheKey` or with `animate: false`.
+
 ## [4.11.1] - 2026-09-08
 
 * **Fix:** Images turned black on web after the widget was scrolled out of view and back. `MultiImageStreamCompleter` re-decoded the codec on every 0→1 listener transition; for a single-frame image on CanvasKit that produces a second lazy `ui.Image` sharing one `<img>` element, and emitting it disposes the previous image, which clears that element's `src`. The already decoded frame is now handed to the returning listener instead. Animated images still resume decoding. Reported by [@tranhuudang](https://github.com/tranhuudang) (issue #67).

--- a/cached_network_image/README.md
+++ b/cached_network_image/README.md
@@ -292,6 +292,63 @@ does not cancel the underlying download. `maxWidthDiskCache` /
 `maxHeightDiskCache` throw an `ArgumentError` when `cacheManager` isn't an
 `ImageCacheManager`.
 
+### Animated Images (GIF)
+
+Set `animate: false` to show only the first frame of a multi-frame image.
+The remaining frames are never decoded.
+
+```dart
+CachedNetworkImage(
+  imageUrl: 'https://example.com/animation.gif',
+  animate: false,
+)
+```
+
+Only the frame callbacks and the `getNextFrame()` calls for the remaining
+frames are skipped. The whole file is still downloaded, cached, read back
+and decoded into a codec, so `animate: false` is not a way to save bandwidth
+or memory on large GIFs.
+
+`animate` is part of the image provider key, so toggling it at runtime
+resolves a different image stream. The widget paints nothing while that
+stream resolves, and which frame it starts on depends on whether its key is
+still held by the `ImageCache` — an animation that played before is likely
+to resume where it left off rather than restart. To pause and resume in
+place without changing the key, wrap the widget in a `TickerMode` instead:
+
+```dart
+TickerMode(
+  enabled: !paused,
+  child: CachedNetworkImage(imageUrl: 'https://example.com/animation.gif'),
+)
+```
+
+`MediaQueryData.disableAnimations` pauses animated images the same way.
+Both need Flutter 3.41 or newer to show the first frame when the image
+loads while already paused ([flutter/flutter#176492](https://github.com/flutter/flutter/pull/176492));
+on older versions a widget that mounts paused stays blank until it resumes.
+`animate: false` has no such requirement and works on every supported
+Flutter version.
+
+On the web this only applies to `ImageRenderMethodForWeb.HttpGet`. The
+default, `HtmlImage`, decodes through an `<img>` element whose codec reports
+a single frame (`HtmlImageElementCodec.frameCount => 1` in the Flutter web
+engine), so animated images never play there and there is nothing for
+`animate` or `TickerMode` to stop:
+
+```dart
+CachedNetworkImage(
+  imageUrl: 'https://example.com/animation.gif',
+  imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
+)
+```
+
+If you need full playback control (play, pause, seek), read the bytes from
+the cache manager yourself (`DefaultCacheManager().getFileStream(url)`, or
+`DefaultCacheManagerWeb` on the web) and hand them to a package such as
+`gif_view`. `CachedNetworkImageProvider` cannot do this: every load path it
+offers returns an `ImageStreamCompleter`, never the bytes.
+
 ### Unsupported Image Formats (SVG, JXL, AVIF, HEIC, ...)
 
 Flutter's built-in image codec can't decode every format. SVG never works

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -34,7 +34,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 5,
+      length: 6,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('CachedNetworkImage CE'),
@@ -46,6 +46,7 @@ class HomePage extends StatelessWidget {
               Tab(icon: Icon(Icons.grid_on), text: 'Grid'),
               Tab(icon: Icon(Icons.speed), text: 'Benchmark'),
               Tab(icon: Icon(Icons.download_done), text: 'PreCache'),
+              Tab(icon: Icon(Icons.gif), text: 'Animate'),
             ],
           ),
         ),
@@ -56,6 +57,7 @@ class HomePage extends StatelessWidget {
             GridContent(),
             BenchmarkContent(),
             PreCacheContent(),
+            AnimateContent(),
           ],
         ),
       ),
@@ -350,6 +352,87 @@ class _PreCacheContentState extends State<PreCacheContent> {
               ),
             ),
           ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Demonstrates the two ways to stop an animated image.
+///
+/// [CachedNetworkImage.animate] is part of the image provider key, so turning
+/// it off resolves a new image stream and the GIF restarts from its first
+/// frame. [TickerMode] pauses and resumes the running animation in place.
+///
+/// Both images ask for [ImageRenderMethodForWeb.HttpGet] because the web
+/// default, `HtmlImage`, decodes through an `<img>` element whose codec
+/// reports a single frame. Animated images never play on that path, so
+/// there would be nothing to stop. The option is ignored off the web.
+class AnimateContent extends StatefulWidget {
+  const AnimateContent({super.key});
+
+  @override
+  State<AnimateContent> createState() => _AnimateContentState();
+}
+
+class _AnimateContentState extends State<AnimateContent> {
+  static const _gifUrl =
+      'https://upload.wikimedia.org/wikipedia/commons/d/d3/Newtons_cradle_animation_book_2.gif';
+
+  bool _animate = true;
+  bool _ticking = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          SwitchListTile(
+            title: const Text('animate'),
+            subtitle: const Text('Freezes on the first frame. Switching back '
+                'on resolves a different provider key.'),
+            value: _animate,
+            onChanged: (value) => setState(() => _animate = value),
+          ),
+          SizedBox(
+            height: 200,
+            child: CachedNetworkImage(
+              imageUrl: _gifUrl,
+              // Both demos load the same URL, and everything the provider
+              // compares is otherwise equal, so without distinct cache keys
+              // they would share one completer and neither switch would
+              // demonstrate anything.
+              cacheKey: '\$_gifUrl#animate',
+              animate: _animate,
+              imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
+              placeholder: (context, url) => const CircularProgressIndicator(),
+              errorBuilder: (context, error, stackTrace) =>
+                  const Icon(Icons.error),
+            ),
+          ),
+          const Divider(height: 32),
+          SwitchListTile(
+            title: const Text('TickerMode'),
+            subtitle: const Text('Pauses and resumes in place. Also what '
+                'MediaQueryData.disableAnimations uses.'),
+            value: _ticking,
+            onChanged: (value) => setState(() => _ticking = value),
+          ),
+          SizedBox(
+            height: 200,
+            child: TickerMode(
+              enabled: _ticking,
+              child: CachedNetworkImage(
+                imageUrl: _gifUrl,
+                cacheKey: '\$_gifUrl#ticker',
+                imageRenderMethodForWeb: ImageRenderMethodForWeb.HttpGet,
+                placeholder: (context, url) =>
+                    const CircularProgressIndicator(),
+                errorBuilder: (context, error, stackTrace) =>
+                    const Icon(Icons.error),
+              ),
+            ),
+          ),
         ],
       ),
     );

--- a/cached_network_image/example/lib/main.dart
+++ b/cached_network_image/example/lib/main.dart
@@ -360,9 +360,12 @@ class _PreCacheContentState extends State<PreCacheContent> {
 
 /// Demonstrates the two ways to stop an animated image.
 ///
-/// [CachedNetworkImage.animate] is part of the image provider key, so turning
-/// it off resolves a new image stream and the GIF restarts from its first
-/// frame. [TickerMode] pauses and resumes the running animation in place.
+/// [CachedNetworkImage.animate] is part of the image provider key, so toggling
+/// it resolves a different image stream: the image goes blank while that
+/// stream resolves, and which frame it comes back on depends on whether its
+/// key is still held by the `ImageCache` — switching animation back on is
+/// likely to resume where it left off rather than restart. [TickerMode]
+/// pauses and resumes the running animation in place, with no key change.
 ///
 /// Both images ask for [ImageRenderMethodForWeb.HttpGet] because the web
 /// default, `HtmlImage`, decodes through an `<img>` element whose codec

--- a/cached_network_image/lib/src/cached_image_widget.dart
+++ b/cached_network_image/lib/src/cached_image_widget.dart
@@ -148,8 +148,12 @@ class CachedNetworkImage extends StatefulWidget {
 
   /// Evict an image from both the disk file based caching system of the
   /// [BaseCacheManager] as the in memory [ImageCache] of the [ImageProvider].
-  /// [url] is used by both the disk and memory cache. The scale is only used
-  /// to clear the image from the [ImageCache].
+  /// [url] is used by both the disk and memory cache. The [cacheKey] and
+  /// [scale] are only used to clear the image from the [ImageCache], and must
+  /// match the ones the widget was rendered with.
+  ///
+  /// [animate] is part of the provider key too, but the caller is not expected
+  /// to know which value the widget used, so both variants are evicted.
   static Future<bool> evictFromCache(
     String url, {
     String? cacheKey,
@@ -159,11 +163,18 @@ class CachedNetworkImage extends StatefulWidget {
   }) async {
     final effectiveCacheManager = _effectiveCacheManager(cacheManager);
     await effectiveCacheManager.removeFile(cacheKey ?? url);
-    return CachedNetworkImageProvider(
-      url,
-      scale: scale,
-      minimumGifFrameDuration: minimumGifFrameDuration,
-    ).evict();
+    var evicted = false;
+    for (final animate in const [true, false]) {
+      final wasCached = await CachedNetworkImageProvider(
+        url,
+        cacheKey: cacheKey,
+        scale: scale,
+        minimumGifFrameDuration: minimumGifFrameDuration,
+        animate: animate,
+      ).evict();
+      evicted = evicted || wasCached;
+    }
+    return evicted;
   }
 
   static BaseCacheManager _effectiveCacheManager(
@@ -353,6 +364,18 @@ class CachedNetworkImage extends StatefulWidget {
   /// durations are extremely short.
   final Duration minimumGifFrameDuration;
 
+  /// Whether multi-frame images, such as GIFs, play automatically.
+  ///
+  /// When false only the first frame is shown and the image is frozen there.
+  /// Defaults to true.
+  ///
+  /// This is part of the image provider key, so toggling it at runtime
+  /// resolves a different image stream. The widget paints nothing while that
+  /// stream resolves, and which frame it starts on depends on whether its key
+  /// is still held by the [ImageCache]. Wrap the widget in a [TickerMode]
+  /// instead to pause and resume an animation in place.
+  final bool animate;
+
   /// When true (the default), the placeholder and fade-in/out animations are
   /// skipped when the image is already available in the disk cache. This
   /// prevents an unnecessary visual flicker for images that load almost
@@ -401,6 +424,7 @@ class CachedNetworkImage extends StatefulWidget {
     this.imageRenderMethodForWeb = ImageRenderMethodForWeb.HtmlImage,
     this.scale = 1.0,
     this.minimumGifFrameDuration = const Duration(milliseconds: 100),
+    this.animate = true,
     this.disablePlaceholderOnCacheHit = true,
   });
 
@@ -450,7 +474,8 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
         oldWidget.maxHeightDiskCache != widget.maxHeightDiskCache ||
         oldWidget.imageRenderMethodForWeb != widget.imageRenderMethodForWeb ||
         oldWidget.scale != widget.scale ||
-        oldWidget.minimumGifFrameDuration != widget.minimumGifFrameDuration;
+        oldWidget.minimumGifFrameDuration != widget.minimumGifFrameDuration ||
+        oldWidget.animate != widget.animate;
 
     // `errorListener` is a callback, and most callers pass a new closure on
     // every build (it can't reasonably be expected to stay identical across
@@ -488,6 +513,7 @@ class _CachedNetworkImageState extends State<CachedNetworkImage> {
       errorListener: widget.errorListener,
       scale: widget.scale,
       minimumGifFrameDuration: widget.minimumGifFrameDuration,
+      animate: widget.animate,
     );
   }
 

--- a/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
+++ b/cached_network_image/lib/src/image_provider/cached_network_image_provider.dart
@@ -24,6 +24,7 @@ class CachedNetworkImageProvider
     this.maxWidth,
     this.scale = 1.0,
     this.minimumGifFrameDuration = const Duration(milliseconds: 100),
+    this.animate = true,
     this.errorListener,
     this.headers,
     this.cacheManager,
@@ -49,6 +50,19 @@ class CachedNetworkImageProvider
   /// The minimum frame duration applied to GIF images when decoded frame
   /// durations are extremely short.
   final Duration minimumGifFrameDuration;
+
+  /// Whether multi-frame images, such as GIFs, play automatically.
+  ///
+  /// When false only the first frame is shown and the image is frozen there.
+  /// Defaults to true.
+  ///
+  /// This is part of the provider key, so toggling it at runtime resolves a
+  /// different image stream. Which frame that stream starts on depends on
+  /// whether its key is still held by the [ImageCache]: an animation that
+  /// played before is likely to resume where it left off rather than restart.
+  /// Use [TickerMode] instead to pause and resume in place without changing
+  /// the key.
+  final bool animate;
 
   /// Listener to be called when images fails to load.
   ///
@@ -96,6 +110,7 @@ class CachedNetworkImageProvider
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       minimumGifFrameDuration: key.minimumGifFrameDuration,
+      animate: key.animate,
       informationCollector: () => <DiagnosticsNode>[
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),
@@ -170,6 +185,7 @@ class CachedNetworkImageProvider
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       minimumGifFrameDuration: key.minimumGifFrameDuration,
+      animate: key.animate,
       informationCollector: () => <DiagnosticsNode>[
         DiagnosticsProperty<ImageProvider>('Image provider', this),
         DiagnosticsProperty<CachedNetworkImageProvider>('Image key', key),
@@ -238,6 +254,7 @@ class CachedNetworkImageProvider
       return ((cacheKey ?? url) == (other.cacheKey ?? other.url)) &&
           scale == other.scale &&
           minimumGifFrameDuration == other.minimumGifFrameDuration &&
+          animate == other.animate &&
           maxHeight == other.maxHeight &&
           maxWidth == other.maxWidth;
     }
@@ -249,6 +266,7 @@ class CachedNetworkImageProvider
         cacheKey ?? url,
         scale,
         minimumGifFrameDuration,
+        animate,
         maxHeight,
         maxWidth,
       );
@@ -257,6 +275,7 @@ class CachedNetworkImageProvider
   String toString() => 'CachedNetworkImageProvider('
       '"$url", '
       'scale: $scale, '
-      'minimumGifFrameDuration: $minimumGifFrameDuration'
+      'minimumGifFrameDuration: $minimumGifFrameDuration, '
+      'animate: $animate'
       ')';
 }

--- a/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
+++ b/cached_network_image/lib/src/image_provider/multi_image_stream_completer.dart
@@ -22,6 +22,7 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     Stream<ImageChunkEvent>? chunkEvents,
     InformationCollector? informationCollector,
     this.minimumGifFrameDuration = const Duration(milliseconds: 100),
+    this.animate = true,
   })  : _informationCollector = informationCollector,
         _scale = scale {
     codec.listen(
@@ -70,6 +71,13 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
   ///
   /// Defaults to 100ms.
   final Duration minimumGifFrameDuration;
+
+  /// Whether multi-frame images, such as GIFs, play automatically.
+  ///
+  /// When false only the first frame is decoded and emitted; the image is
+  /// frozen there. Defaults to true.
+  final bool animate;
+
   ui.FrameInfo? _nextFrame;
 
   // When the current was first shown.
@@ -108,6 +116,15 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     final previousCodec = _codec;
     _codec = codec;
     _framesEmitted = 0;
+    if (!animate) {
+      // A paused image has no cycle to keep in step with, so the incoming
+      // codec's first frame is a first frame again. Leaving the outgoing
+      // codec's timing in place would hold the replacement back for up to a
+      // frame duration and arm a timer that nothing in the paused lifecycle
+      // ever clears, stranding every codec that follows.
+      _frameDuration = null;
+      _shownTimestamp = null;
+    }
 
     if (previousCodec != null &&
         previousCodec != codec &&
@@ -170,6 +187,11 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
   }
 
   Future<void> _decodeNextFrameAndSchedule() async {
+    if (!animate && _framesEmitted > 0) {
+      // Paused: the current codec has shown its first frame and nothing more
+      // should be decoded from it, including when a listener is re-added.
+      return;
+    }
     final codec = _codec!;
     if (_decodingCodecs.contains(codec)) {
       // A decode of this codec is already pending. A second concurrent decode
@@ -254,10 +276,17 @@ class MultiImageStreamCompleter extends ImageStreamCompleter {
     // codec renders black on the web, where CanvasKit images lazily reference a
     // single shared <img> element that is cleared when the previous frame is
     // disposed.
-    if (!hasListeners &&
-        _codec != null &&
-        (_framesEmitted == 0 || _codec!.frameCount > 1)) {
-      _decodeNextFrameAndSchedule();
+    if (!hasListeners && _codec != null) {
+      if (!animate && _nextFrame != null) {
+        // A frame decoded for the departed listener is still in hand. A
+        // paused image shows that one rather than decoding again, which
+        // would drop it and advance the codec past the frame the image is
+        // meant to stop on. An animating image keeps re-decoding, as its
+        // held frame is stale by the time a listener returns.
+        _scheduleAppFrame();
+      } else if (_framesEmitted == 0 || _codec!.frameCount > 1) {
+        _decodeNextFrameAndSchedule();
+      }
     }
     super.addListener(listener);
   }

--- a/cached_network_image/pubspec.yaml
+++ b/cached_network_image/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - cache
   - image
   - network-image
-version: 4.11.1
+version: 4.12.0
 
 environment:
   sdk: ^3.0.0

--- a/cached_network_image/test/cached_image_widget_test.dart
+++ b/cached_network_image/test/cached_image_widget_test.dart
@@ -61,7 +61,8 @@ void main() {
       );
       expect(evicted, isTrue);
 
-      expect(PaintingBinding.instance.imageCache.containsKey(provider), isFalse);
+      expect(
+          PaintingBinding.instance.imageCache.containsKey(provider), isFalse);
     });
 
     test('evicts the cache entry of an image with a cacheKey', () async {
@@ -86,7 +87,8 @@ void main() {
         cacheManager: mockCacheManager,
       );
 
-      expect(PaintingBinding.instance.imageCache.containsKey(provider), isFalse);
+      expect(
+          PaintingBinding.instance.imageCache.containsKey(provider), isFalse);
     });
 
     test('uses cacheKey when provided', () async {

--- a/cached_network_image/test/cached_image_widget_test.dart
+++ b/cached_network_image/test/cached_image_widget_test.dart
@@ -1,7 +1,9 @@
 import 'package:cached_network_image_ce/cached_network_image.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:octo_image/octo_image.dart';
 
 import 'fake_cache_manager.dart';
 import 'image_data.dart';
@@ -33,6 +35,58 @@ void main() {
 
       verify(() => mockCacheManager.removeFile('https://example.com/img.png'))
           .called(1);
+    });
+
+    test('evicts the cache entry of a paused image', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      final mockCacheManager = MockBaseCacheManager();
+      when(() => mockCacheManager.removeFile(any())).thenAnswer((_) async {});
+      const url = 'https://example.com/img.gif';
+      const provider = CachedNetworkImageProvider(url, animate: false);
+
+      final image = await createTestImage();
+      PaintingBinding.instance.imageCache.putIfAbsent(
+        provider,
+        () => OneFrameImageStreamCompleter(
+          SynchronousFuture<ImageInfo>(ImageInfo(image: image)),
+        ),
+      );
+      expect(PaintingBinding.instance.imageCache.containsKey(provider), isTrue);
+
+      // The caller does not have to know which `animate` the widget used, and
+      // the result reports the eviction whichever variant it matched.
+      final evicted = await CachedNetworkImage.evictFromCache(
+        url,
+        cacheManager: mockCacheManager,
+      );
+      expect(evicted, isTrue);
+
+      expect(PaintingBinding.instance.imageCache.containsKey(provider), isFalse);
+    });
+
+    test('evicts the cache entry of an image with a cacheKey', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      final mockCacheManager = MockBaseCacheManager();
+      when(() => mockCacheManager.removeFile(any())).thenAnswer((_) async {});
+      const url = 'https://example.com/keyed.png';
+      const provider = CachedNetworkImageProvider(url, cacheKey: 'custom-key');
+
+      final image = await createTestImage();
+      PaintingBinding.instance.imageCache.putIfAbsent(
+        provider,
+        () => OneFrameImageStreamCompleter(
+          SynchronousFuture<ImageInfo>(ImageInfo(image: image)),
+        ),
+      );
+      expect(PaintingBinding.instance.imageCache.containsKey(provider), isTrue);
+
+      await CachedNetworkImage.evictFromCache(
+        url,
+        cacheKey: 'custom-key',
+        cacheManager: mockCacheManager,
+      );
+
+      expect(PaintingBinding.instance.imageCache.containsKey(provider), isFalse);
     });
 
     test('uses cacheKey when provided', () async {
@@ -209,6 +263,27 @@ void main() {
       );
       await tester.pump();
       expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('passes animate to the image provider', (tester) async {
+      var imageUrl = 'animate-test';
+      cacheManager.returns(imageUrl, kTransparentImage);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CachedNetworkImage(
+              imageUrl: imageUrl,
+              cacheManager: cacheManager,
+              animate: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final octoImage = tester.widget<OctoImage>(find.byType(OctoImage));
+      expect((octoImage.image as CachedNetworkImageProvider).animate, isFalse);
     });
 
     testWidgets('useOldImageOnUrlChange works without error', (tester) async {

--- a/cached_network_image/test/cached_network_image_provider_test.dart
+++ b/cached_network_image/test/cached_network_image_provider_test.dart
@@ -3,6 +3,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'fake_cache_manager.dart';
+import 'image_data.dart';
+
 void main() {
   group('CachedNetworkImageProvider', () {
     group('equality', () {
@@ -93,6 +96,18 @@ void main() {
         expect(a, isNot(equals(b)));
       });
 
+      test('different animate are not equal', () {
+        const a = CachedNetworkImageProvider(
+          'https://example.com/img.gif',
+        );
+        const b = CachedNetworkImageProvider(
+          'https://example.com/img.gif',
+          animate: false,
+        );
+        expect(a, isNot(equals(b)));
+        expect(a.hashCode, isNot(equals(b.hashCode)));
+      });
+
       test('not equal to non-CachedNetworkImageProvider', () {
         const a = CachedNetworkImageProvider('https://example.com/img.png');
         expect(a == Object(), isFalse);
@@ -141,6 +156,47 @@ void main() {
         expect(result, contains('https://example.com/img.png'));
         expect(result, contains('2.0'));
         expect(result, contains('0:00:00.150000'));
+      });
+    });
+
+    group('animate', () {
+      test('is handed to the completer by loadImage', () {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        final cacheManager = FakeCacheManager();
+        cacheManager.returns('animate-load-image', kTransparentImage);
+        final provider = CachedNetworkImageProvider(
+          'animate-load-image',
+          cacheManager: cacheManager,
+          animate: false,
+        );
+
+        final completer = provider.loadImage(
+          provider,
+          PaintingBinding.instance.instantiateImageCodecWithSize,
+        ) as MultiImageStreamCompleter;
+
+        expect(completer.animate, isFalse);
+      });
+
+      test('is handed to the completer by loadBuffer', () {
+        TestWidgetsFlutterBinding.ensureInitialized();
+        final cacheManager = FakeCacheManager();
+        cacheManager.returns('animate-load-buffer', kTransparentImage);
+        final provider = CachedNetworkImageProvider(
+          'animate-load-buffer',
+          cacheManager: cacheManager,
+          animate: false,
+        );
+
+        final completer = provider
+            // ignore: deprecated_member_use_from_same_package
+            .loadBuffer(
+          provider,
+          // ignore: deprecated_member_use
+          PaintingBinding.instance.instantiateImageCodecFromBuffer,
+        ) as MultiImageStreamCompleter;
+
+        expect(completer.animate, isFalse);
       });
     });
 

--- a/cached_network_image/test/image_stream_completer_test.dart
+++ b/cached_network_image/test/image_stream_completer_test.dart
@@ -86,10 +86,12 @@ class FakeEventReportingImageStreamCompleter extends ImageStreamCompleter {
 void main() {
   late Image image20x10;
   late Image image200x100;
+  late Image image50x50;
   late Image image300x100;
   setUp(() async {
     image20x10 = await createTestImage(width: 20, height: 10);
     image200x100 = await createTestImage(width: 200, height: 100);
+    image50x50 = await createTestImage(width: 50, height: 50);
     image300x100 = await createTestImage(width: 300, height: 100);
   });
 
@@ -1460,4 +1462,155 @@ void main() {
     expect(firstCodec.numFramesAsked, 3);
     expect(secondCodec.numFramesAsked, 1);
   });
+
+  testWidgets(
+    'animate: false emits only the first frame of an animated image',
+    (WidgetTester tester) async {
+      final mockCodec = MockCodec()
+        ..frameCount = 3
+        ..repetitionCount = -1;
+      final codecStream = StreamController<Codec>();
+
+      final ImageStreamCompleter imageStream = MultiImageStreamCompleter(
+        codec: codecStream.stream,
+        scale: 1.0,
+        animate: false,
+      );
+
+      final emittedImages = <ImageInfo>[];
+      imageStream.addListener(
+        ImageStreamListener((ImageInfo image, bool synchronousCall) {
+          emittedImages.add(image);
+        }),
+      );
+
+      codecStream.add(mockCodec);
+      await tester.idle();
+
+      final FrameInfo frame1 =
+          FakeFrameInfo(const Duration(milliseconds: 200), image20x10);
+      mockCodec.completeNextFrame(frame1);
+      await tester.idle();
+
+      await tester.pump();
+      expect(emittedImages.single.image.isCloneOf(frame1.image), true);
+      expect(mockCodec.numFramesAsked, 1);
+
+      // No further frames are decoded or emitted, and no timer is left behind.
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(emittedImages.length, 1);
+      expect(mockCodec.numFramesAsked, 1);
+    },
+  );
+
+  testWidgets(
+    'animate: false keeps its decoded frame across a listener re-add',
+    (WidgetTester tester) async {
+      final mockCodec = MockCodec()
+        ..frameCount = 3
+        ..repetitionCount = -1;
+      final codecStream = StreamController<Codec>();
+
+      final ImageStreamCompleter imageStream = MultiImageStreamCompleter(
+        codec: codecStream.stream,
+        scale: 1.0,
+        animate: false,
+      );
+      // The ImageCache holds a handle for every live entry, so the completer
+      // survives its last listener leaving.
+      final handle = imageStream.keepAlive();
+
+      final emittedImages = <ImageInfo>[];
+      final listener = ImageStreamListener(
+        (ImageInfo image, bool synchronousCall) => emittedImages.add(image),
+      );
+      imageStream.addListener(listener);
+
+      codecStream.add(mockCodec);
+      await tester.idle();
+
+      final FrameInfo frame1 =
+          FakeFrameInfo(const Duration(milliseconds: 200), image20x10);
+      mockCodec.completeNextFrame(frame1);
+      await tester.idle();
+
+      // The listener leaves before the scheduled app frame runs, as happens
+      // when the image scrolls off screen while it is still loading.
+      imageStream.removeListener(listener);
+      await tester.pump();
+      expect(emittedImages, isEmpty);
+
+      imageStream.addListener(listener);
+      await tester.pump();
+
+      // The frame already in hand is shown; the codec is not advanced.
+      expect(mockCodec.numFramesAsked, 1);
+      expect(emittedImages.single.image.isCloneOf(frame1.image), true);
+
+      handle.dispose();
+    },
+  );
+
+  testWidgets(
+    'animate: false shows a replacement codec without waiting',
+    (WidgetTester tester) async {
+      final firstCodec = MockCodec()
+        ..frameCount = 2
+        ..repetitionCount = -1;
+      final secondCodec = MockCodec()
+        ..frameCount = 2
+        ..repetitionCount = -1;
+      final thirdCodec = MockCodec()
+        ..frameCount = 2
+        ..repetitionCount = -1;
+      final codecStream = StreamController<Codec>();
+
+      final ImageStreamCompleter imageStream = MultiImageStreamCompleter(
+        codec: codecStream.stream,
+        scale: 1.0,
+        animate: false,
+      );
+
+      final emittedImages = <ImageInfo>[];
+      imageStream.addListener(
+        ImageStreamListener(
+          (ImageInfo image, bool synchronousCall) => emittedImages.add(image),
+        ),
+      );
+
+      codecStream.add(firstCodec);
+      await tester.idle();
+      firstCodec.completeNextFrame(
+        FakeFrameInfo(const Duration(milliseconds: 200), image20x10),
+      );
+      await tester.idle();
+      await tester.pump();
+      expect(emittedImages.length, 1);
+
+      // A paused image has no frame duration to wait out, so a replacement
+      // codec is shown as soon as its first frame is decoded.
+      codecStream.add(secondCodec);
+      await tester.idle();
+      final FrameInfo secondFrame =
+          FakeFrameInfo(const Duration(milliseconds: 400), image200x100);
+      secondCodec.completeNextFrame(secondFrame);
+      await tester.idle();
+      await tester.pump();
+      expect(emittedImages.length, 2);
+      expect(emittedImages.last.image.isCloneOf(secondFrame.image), true);
+
+      // No timer is left armed, so a further codec is handled rather than
+      // buffered and stranded.
+      codecStream.add(thirdCodec);
+      await tester.idle();
+      expect(thirdCodec.numFramesAsked, 1);
+      final FrameInfo thirdFrame =
+          FakeFrameInfo(const Duration(milliseconds: 200), image50x50);
+      thirdCodec.completeNextFrame(thirdFrame);
+      await tester.idle();
+      await tester.pump();
+      expect(emittedImages.length, 3);
+      expect(emittedImages.last.image.isCloneOf(thirdFrame.image), true);
+    },
+  );
 }


### PR DESCRIPTION
## Description

Introduce an `animate` parameter to `CachedNetworkImage` and `CachedNetworkImageProvider` for controlling playback of multi-frame images like GIFs. Update cache eviction logic to handle both animated and non-animated entries. Enhance documentation and add tests to ensure functionality.

## Related Issues

*Fixes #21*

## Checklist

- [x] I've read the [Contributor Guide]
- [x] All existing tests pass
- [x] I've added new tests for any new features or bug fixes
- [x] I've updated the CHANGELOG if applicable



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `animate` option for cached images, allowing animated images such as GIFs to display only their first frame.
  * Added an example demonstrating animation toggling and pause/resume behavior.
  * Updated documentation with usage guidance and web-specific behavior.

* **Bug Fixes**
  * Improved cache eviction to clear both animated and non-animated image variants.
  * Ensured custom cache keys are correctly handled during eviction.

* **Chores**
  * Updated the package version to 4.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->